### PR TITLE
Initial F32Ext trait with abs, atan2, and sqrt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ analysis.
     - [ ] `asin`
     - [ ] `acos`
     - [ ] `atan`
-    - [ ] `atan2`
+    - [x] `atan2`
     - [ ] `cos`
     - [ ] `hypot`
     - [ ] `invsqrt`
@@ -29,10 +29,10 @@ analysis.
     - [ ] `log10`
     - [ ] `powf`
     - [ ] `sin`
-    - [ ] `sqrt`
+    - [x] `sqrt`
     - [ ] `tan`
   - `std` polyfills:
-    - [ ] `abs`
+    - [x] `abs`
     - [ ] `ceil`
     - [ ] `floor`
     - [ ] `round`
@@ -55,9 +55,9 @@ analysis.
     - [ ] `U32x3`
     - [ ] `F32x3`
 - Statistical analysis:
-  - `mean`
-  - `variance`
-  - `stddev`
+  - [ ] `mean`
+  - [ ] `variance`
+  - [ ] `stddev`
 - Quaternions
   - [ ] TBD
 

--- a/src/f32ext.rs
+++ b/src/f32ext.rs
@@ -1,0 +1,42 @@
+/// `f32` extension providing various arithmetic approximations and polyfills
+/// for `std` functionality.
+mod abs;
+mod atan2;
+mod radians;
+mod sqrt;
+
+/// `f32` extension providing various arithmetic approximations and polyfills
+/// for `std` functionality.
+pub trait F32Ext: Sized {
+    /// Compute absolute value.
+    ///
+    /// Provides a constant-time, data-independent implementation.
+    fn abs(self) -> f32;
+
+    /// Compute four quadrant arctangent normalized between `[0, 4)`
+    fn atan2_norm(self, other: f32) -> f32;
+
+    /// Compute four quadrant arctangent
+    fn atan2(self, other: f32) -> f32;
+
+    /// Compute square root
+    fn sqrt(self) -> f32;
+}
+
+impl F32Ext for f32 {
+    fn abs(self) -> f32 {
+        self::abs::abs(self)
+    }
+
+    fn atan2_norm(self, other: f32) -> f32 {
+        self::atan2::atan2_norm_approx(self, other)
+    }
+
+    fn atan2(self, other: f32) -> f32 {
+        self::atan2::atan2_approx(self, other)
+    }
+
+    fn sqrt(self) -> f32 {
+        self::sqrt::sqrt_approx(self)
+    }
+}

--- a/src/f32ext/abs.rs
+++ b/src/f32ext/abs.rs
@@ -1,0 +1,16 @@
+/// Compute the absolute value of `n`
+/// Method described at: <https://bits.stephan-brumme.com/absFloat.html>
+pub(super) fn abs(n: f32) -> f32 {
+    f32::from_bits(n.to_bits() & 0x7FFF_FFFF)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abs_test() {
+        assert_eq!(abs(1.0), 1.0);
+        assert_eq!(abs(-1.0), 1.0);
+    }
+}

--- a/src/f32ext/atan2.rs
+++ b/src/f32ext/atan2.rs
@@ -1,0 +1,62 @@
+use super::{abs::abs, radians::radians_norm};
+
+/// Computes an `atan2` approximation in radians (see below)
+pub(super) fn atan2_approx(y: f32, x: f32) -> f32 {
+    radians_norm(atan2_norm_approx(y, x))
+}
+
+/// Approximates the four quadrant arctangent for a single-precision float.
+/// Normalized to the `[0, 4)` range with a maximum error of `0.1620` degrees.
+///
+/// Method described at: <https://ieeexplore.ieee.org/document/6375931>
+pub(super) fn atan2_norm_approx(y: f32, x: f32) -> f32 {
+    const SIGN_MASK: u32 = 0x8000_0000;
+    const B: f32 = 0.596_227;
+
+    // Extract sign bits from floating point values
+    let ux_s = SIGN_MASK & x.to_bits();
+    let uy_s = SIGN_MASK & y.to_bits();
+
+    // Determine quadrant offset
+    let q = ((!ux_s & uy_s) >> 29 | ux_s >> 30) as f32;
+
+    // Calculate arctangent in the first quadrant
+    let bxy_a = abs(B * x * y);
+    let n = bxy_a + y * y;
+    let atan_1q = n / (x * x + bxy_a + n);
+
+    // Translate it to the proper quadrant
+    let uatan_2q = (ux_s ^ uy_s) | atan_1q.to_bits();
+    q + f32::from_bits(uatan_2q)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::f32::consts::PI;
+
+    #[test]
+    fn atan2_approx_test() {
+        let atan2_test_vectors = [
+            (0.0, 1.0, 0.0),
+            (0.0, -1.0, PI),
+            (3.0, 2.0, (3.0f32 / 2.0).atan()),
+            (2.0, -1.0, (2.0f32 / -1.0).atan() + PI),
+            (-2.0, -1.0, (-2.0f32 / -1.0).atan() - PI),
+        ];
+
+        for (y, x, expected) in &atan2_test_vectors {
+            let actual = atan2_approx(*y, *x);
+            let delta = actual - expected;
+
+            assert!(
+                // 0.1620 degrees in radians
+                delta <= 0.003,
+                "delta {} too large: {} vs {}",
+                delta,
+                actual,
+                expected
+            );
+        }
+    }
+}

--- a/src/f32ext/radians.rs
+++ b/src/f32ext/radians.rs
@@ -1,0 +1,20 @@
+use core::f32::consts::PI;
+
+/// Assuming `n` is normalized between `[0, 4)`, compute radians
+pub(super) fn radians_norm(n: f32) -> f32 {
+    PI / 2.0 * if n > 2.0 { n - 4.0 } else { n }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn radians_norm_test() {
+        assert_eq!(radians_norm(0.0), 0.0);
+        assert_eq!(radians_norm(1.0), PI / 2.0);
+        assert_eq!(radians_norm(2.0), PI);
+        assert_eq!(radians_norm(3.0), -PI / 2.0);
+        assert_eq!(radians_norm(4.0), 0.0);
+    }
+}

--- a/src/f32ext/sqrt.rs
+++ b/src/f32ext/sqrt.rs
@@ -1,0 +1,52 @@
+/// Square root approximation function for a single-precision float.
+/// Method described at: <https://bits.stephan-brumme.com/squareRoot.html>
+pub(super) fn sqrt_approx(n: f32) -> f32 {
+    let mut n = n.to_bits();
+    n += 127 << 23;
+    n >>= 1;
+    f32::from_bits(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sqrt_approx_test() {
+        let sqrt_test_vectors = [
+            (1.0, 1.0),
+            (2.0, 1.414),
+            (3.0, 1.732),
+            (4.0, 2.0),
+            (5.0, 2.236),
+            (10.0, 3.162),
+            (100.0, 10.0),
+            (250.0, 15.811),
+            (500.0, 22.36),
+            (1000.0, 31.622),
+            (2500.0, 50.0),
+            (5000.0, 70.710),
+            (1000000.0, 1000.0),
+            (2500000.0, 1581.138),
+            (5000000.0, 2236.067),
+            (10000000.0, 3162.277),
+            (25000000.0, 5000.0),
+            (50000000.0, 7071.067),
+            (100000000.0, 10000.0),
+        ];
+
+        for (x, expected) in &sqrt_test_vectors {
+            let sqrt_x = sqrt_approx(*x);
+            let allowed_delta = x * 0.05;
+            let actual_delta = sqrt_x - expected;
+
+            assert!(
+                actual_delta <= allowed_delta,
+                "delta {} too large: {} vs {}",
+                actual_delta,
+                sqrt_x,
+                expected
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,19 @@
+//! Embedded math library featuring fast, safe floating point approximations
+//! for common arithmetic operations, 2D and 3D vector types, and statistical
+//! analysis.
+
 #![no_std]
+#![deny(
+    warnings,
+    missing_docs,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_import_braces,
+    unused_qualifications
+)]
+#![forbid(unsafe_code)]
+#![doc(html_root_url = "https://docs.rs/micromath/0.0.0")]
+
+mod f32ext;
+
+pub use f32ext::F32Ext;


### PR DESCRIPTION
Imports the existing `f32` extension from the `accelerometer` crate,
along with the arithmetic operations it previously impl'd:

- `abs`
- `atan2`
- `sqrt`