### PR TITLE
2D/3D vector support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ rust: stable
 os: linux
 cache: cargo
 
-branches:
-  only:
-    - master
-
 install:
   - rustup component add rustfmt
   - rustup component add clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ keywords    = ["math", "vector"]
 generic-array = { version = "0.12", default-features = false }
 
 [features]
-default = ["vectors"]
-vectors = []
+default = ["vector"]
+vector = []
 
 [badges]
 travis-ci = { repository = "NeoBirth/micromath" }

--- a/README.md
+++ b/README.md
@@ -39,21 +39,21 @@ analysis.
     - [ ] `trunc`
 - Algebraic vector types:
   - 2D:
-    - [ ] `I8x2`
-    - [ ] `I16x2`
+    - [x] `I8x2`
+    - [x] `I16x2`
     - [ ] `I32x2`
-    - [ ] `U8x2`
-    - [ ] `U16x2`
+    - [x] `U8x2`
+    - [x] `U16x2`
     - [ ] `U32x2`
-    - [ ] `F32x2`
+    - [x] `F32x2`
   - 3D:
-    - [ ] `I8x3`
-    - [ ] `I16x3`
+    - [x] `I8x3`
+    - [x] `I16x3`
     - [ ] `I32x3`
-    - [ ] `U8x3`
-    - [ ] `U16x3`
+    - [x] `U8x3`
+    - [x] `U16x3`
     - [ ] `U32x3`
-    - [ ] `F32x3`
+    - [x] `F32x3`
 - Statistical analysis:
   - [ ] `mean`
   - [ ] `variance`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,7 @@
 #![doc(html_root_url = "https://docs.rs/micromath/0.0.0")]
 
 mod f32ext;
+#[cfg(feature = "vector")]
+pub mod vector;
 
 pub use f32ext::F32Ext;

--- a/src/vector/component.rs
+++ b/src/vector/component.rs
@@ -1,0 +1,26 @@
+//! Traits for vector components
+
+use core::ops::{Add, Div, Mul, Sub};
+
+/// Vector components
+pub trait Component:
+    Copy
+    + Default
+    + Sized
+    + Add<Output = Self>
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + Div<Output = Self>
+    + PartialOrd
+    + PartialEq
+    + Into<f32>
+{
+}
+
+impl Component for i8 {}
+impl Component for i16 {}
+// TODO: impl Component for i32 {}
+impl Component for u8 {}
+impl Component for u16 {}
+// TODO: impl Component for u32 {}
+impl Component for f32 {}

--- a/src/vector/iter.rs
+++ b/src/vector/iter.rs
@@ -1,0 +1,39 @@
+use super::Vector;
+
+/// Iterator over the components of an algebraic vector
+pub struct Iter<'a, V>
+where
+    V: Vector,
+{
+    /// Reference to the original vector
+    vector: &'a V,
+
+    /// Iteration position within the vector
+    position: usize,
+}
+
+impl<'a, V> Iter<'a, V>
+where
+    V: Vector,
+{
+    /// Create a new iterator over the vector's components
+    pub(super) fn new(vector: &'a V) -> Self {
+        Self {
+            vector,
+            position: 0,
+        }
+    }
+}
+
+impl<'a, V> Iterator for Iter<'a, V>
+where
+    V: Vector,
+{
+    type Item = V::Component;
+
+    fn next(&mut self) -> Option<V::Component> {
+        let item = self.vector.get(self.position);
+        self.position += 1;
+        item
+    }
+}

--- a/src/vector/mod.rs
+++ b/src/vector/mod.rs
@@ -1,0 +1,79 @@
+//! Algebraic vector types generic over a number of axes and a component type
+
+#[allow(unused_imports)]
+use crate::f32ext::F32Ext;
+use core::{
+    fmt::Debug,
+    ops::{Index, MulAssign},
+};
+use generic_array::{ArrayLength, GenericArray};
+
+mod component;
+mod iter;
+mod xy;
+mod xyz;
+
+pub use self::{component::*, iter::*, xy::*, xyz::*};
+
+/// Vectors with numeric components
+pub trait Vector:
+    Copy + Debug + Default + Index<usize> + MulAssign<f32> + PartialEq + Sized + Send + Sync
+{
+    /// Type representing measured acceleration for a particular axis
+    type Component: Component;
+
+    /// Number of axes
+    type Axes: ArrayLength<Self::Component>;
+
+    /// Smallest value representable by a vector component
+    const MIN: Self::Component;
+
+    /// Largest value representable by a vector component
+    const MAX: Self::Component;
+
+    /// Instantiate a `Vector` from an iterator over `Self::Component` values.
+    ///
+    /// Panics of the iterator is not the correct length.
+    fn from_iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Self::Component>;
+
+    /// Instantiate a vector from a slice of components.
+    ///
+    /// Panics if the slice is not the right size.
+    fn from_slice(slice: &[Self::Component]) -> Self {
+        Self::from_iter(slice.iter().cloned())
+    }
+
+    /// Get the component value for a particular index
+    fn get(self, index: usize) -> Option<Self::Component>;
+
+    /// Iterate over the components of a vector
+    fn iter(&self) -> Iter<Self> {
+        Iter::new(self)
+    }
+
+    /// Compute the distance between two vectors
+    fn distance(self, other: Self) -> f32 {
+        let differences = self
+            .iter()
+            .zip(other.iter())
+            .map(|(a, b)| a.into() - b.into());
+
+        differences.map(|n| n * n).sum::<f32>().sqrt()
+    }
+
+    /// Compute the magnitude of a vector
+    fn magnitude(self) -> f32 {
+        self.iter()
+            .map(|n| {
+                let n = n.into();
+                n * n
+            })
+            .sum::<f32>()
+            .sqrt()
+    }
+
+    /// Obtain an array of the acceleration components for each of the axes
+    fn to_array(self) -> GenericArray<Self::Component, Self::Axes>;
+}

--- a/src/vector/xy.rs
+++ b/src/vector/xy.rs
@@ -1,0 +1,145 @@
+//! 2-dimensional vectors (X,Y)
+
+use super::Vector;
+use core::ops::{Index, MulAssign};
+use generic_array::{arr, arr_impl, typenum::U2, GenericArray};
+
+macro_rules! impl_2d_vector {
+    ($vector:ident, $component:tt, $doc:expr) => {
+        #[doc=$doc]
+        #[derive(Copy, Clone, Debug, Default, PartialEq)]
+        pub struct $vector {
+            /// X component
+            pub x: $component,
+
+            /// Y component
+            pub y: $component,
+        }
+
+        impl $vector {
+            /// Instantiate from X and Y components
+            pub fn new(x: $component, y: $component) -> Self {
+                $vector { x, y }
+            }
+        }
+
+        impl Vector for $vector {
+            type Component = $component;
+            type Axes = U2;
+
+            const MIN: $component = core::$component::MIN;
+            const MAX: $component = core::$component::MAX;
+
+            fn from_iter<I>(into_iter: I) -> Self
+            where
+                I: IntoIterator<Item = Self::Component>
+            {
+                let mut iter = into_iter.into_iter();
+
+                let x = iter.next().expect("no x-axis component in slice");
+                let y = iter.next().expect("no y-axis component in slice");
+                debug_assert!(iter.next().is_none(), "too many items in 2-dimensional component slice");
+
+                Self::new(x, y)
+            }
+
+            fn get(self, i: usize) -> Option<Self::Component> {
+                if i <= 1 {
+                    Some(self[i])
+                } else {
+                    None
+                }
+            }
+
+            fn to_array(self) -> GenericArray<$component, U2> {
+                arr![$component; self.x, self.y]
+            }
+        }
+
+        impl From<($component, $component)> for $vector {
+            fn from(vector: ($component, $component)) -> Self {
+                $vector::new(vector.0, vector.1)
+            }
+        }
+
+        impl Index<usize> for $vector {
+            type Output = $component;
+
+            fn index(&self, i: usize) -> &$component {
+                match i {
+                    0 => &self.x,
+                    1 => &self.y,
+                    _ => panic!("index out of range")
+                }
+            }
+        }
+
+        impl MulAssign<f32> for $vector {
+            #[allow(trivial_numeric_casts)]
+            fn mul_assign(&mut self, n: f32) {
+                self.x = (f32::from(self.x) * n) as $component;
+                self.y = (f32::from(self.y) * n) as $component;
+            }
+        }
+    }
+}
+
+impl_2d_vector!(I8x2, i8, "2-dimensional XY vector of `i8` values");
+impl_2d_vector!(I16x2, i16, "2-dimensional XY vector of `i16` values");
+// TODO: impl_2d_vector!(I32x2, i32, "2-dimensional XY vector of `i32` values");
+impl_2d_vector!(U8x2, u8, "2-dimensional XY vector of `u8` values");
+impl_2d_vector!(U16x2, u16, "2-dimensional XY vector of `u16` values");
+// TODO: impl_2d_vector!(U32x2, u32, "2-dimensional XY vector of `u32` values");
+impl_2d_vector!(F32x2, f32, "2-dimensional XY vector of `f32` values");
+
+impl MulAssign<i8> for I8x2 {
+    fn mul_assign(&mut self, n: i8) {
+        self.x *= n;
+        self.y *= n;
+    }
+}
+
+impl MulAssign<i16> for I16x2 {
+    fn mul_assign(&mut self, n: i16) {
+        self.x *= n;
+        self.y *= n;
+    }
+}
+
+impl MulAssign<u8> for U8x2 {
+    fn mul_assign(&mut self, n: u8) {
+        self.x *= n;
+        self.y *= n;
+    }
+}
+
+impl MulAssign<u16> for U16x2 {
+    fn mul_assign(&mut self, n: u16) {
+        self.x *= n;
+        self.y *= n;
+    }
+}
+
+impl From<I8x2> for F32x2 {
+    fn from(vector: I8x2) -> F32x2 {
+        F32x2::new(vector.x.into(), vector.y.into())
+    }
+}
+
+impl From<I16x2> for F32x2 {
+    fn from(vector: I16x2) -> F32x2 {
+        F32x2::new(vector.x.into(), vector.y.into())
+    }
+}
+
+impl From<U8x2> for F32x2 {
+    fn from(vector: U8x2) -> F32x2 {
+        F32x2::new(vector.x.into(), vector.y.into())
+    }
+}
+
+impl From<U16x2> for F32x2 {
+    fn from(vector: U16x2) -> F32x2 {
+        F32x2::new(vector.x.into(), vector.y.into())
+    }
+}

--- a/src/vector/xyz.rs
+++ b/src/vector/xyz.rs
@@ -1,0 +1,123 @@
+//! 3-dimensional vectors (X,Y,Z)
+
+use super::Vector;
+use core::ops::{Index, MulAssign};
+use generic_array::{arr, arr_impl, typenum::U3, GenericArray};
+
+macro_rules! impl_3d_vector {
+    ($vector:ident, $component:tt, $doc:expr) => {
+        #[doc=$doc]
+        #[derive(Copy, Clone, Debug, Default, PartialEq)]
+        pub struct $vector {
+            /// X component
+            pub x: $component,
+
+            /// Y component
+            pub y: $component,
+
+            /// Z component
+            pub z: $component,
+        }
+
+        impl $vector {
+            /// Instantiate from X,Y,Z components
+            pub fn new(x: $component, y: $component, z: $component) -> Self {
+                $vector { x, y, z }
+            }
+        }
+
+        impl Vector for $vector {
+            type Component = $component;
+            type Axes = U3;
+
+            const MIN: $component = core::$component::MIN;
+            const MAX: $component = core::$component::MAX;
+
+            fn from_iter<I>(into_iter: I) -> Self
+            where
+                I: IntoIterator<Item = Self::Component>
+            {
+                let mut iter = into_iter.into_iter();
+
+                let x = iter.next().expect("no x-axis component in slice");
+                let y = iter.next().expect("no y-axis component in slice");
+                let z = iter.next().expect("no z-axis component in slice");
+                debug_assert!(iter.next().is_none(), "too many items in 3-axis component slice");
+
+                Self::new(x, y, z)
+            }
+
+            fn get(self, i: usize) -> Option<Self::Component> {
+                if i <= 2 {
+                    Some(self[i])
+                } else {
+                    None
+                }
+            }
+
+            fn to_array(self) -> GenericArray<$component, U3> {
+                arr![$component; self.x, self.y, self.z]
+            }
+        }
+
+        impl From<($component, $component, $component)> for $vector {
+            fn from(vector: ($component, $component, $component)) -> Self {
+                $vector::new(vector.0, vector.1, vector.2)
+            }
+        }
+
+        impl Index<usize> for $vector {
+            type Output = $component;
+
+            fn index(&self, i: usize) -> &$component {
+                match i {
+                    0 => &self.x,
+                    1 => &self.y,
+                    2 => &self.z,
+                    _ => panic!("index out of range")
+                }
+            }
+        }
+
+        impl MulAssign<f32> for $vector {
+            #[allow(trivial_numeric_casts)]
+            fn mul_assign(&mut self, n: f32) {
+                self.x = (f32::from(self.x) * n) as $component;
+                self.y = (f32::from(self.y) * n) as $component;
+                self.z = (f32::from(self.z) * n) as $component;
+            }
+        }
+    }
+}
+
+impl_3d_vector!(I8x3, i8, "3-dimensional XYZ vector of `i8` values");
+impl_3d_vector!(I16x3, i16, "3-dimensional XYZ vector of `i16` values");
+// TODO: impl_3d_vector!(I32x3, i32, "3-dimensional XYZ vector of `i32` values");
+impl_3d_vector!(U8x3, u8, "3-dimensional XYZ vector of `u8` values");
+impl_3d_vector!(U16x3, u16, "3-dimensional XYZ vector of `u16` values");
+// TODO: impl_3d_vector!(U32x3, u32, "3-dimensional XYZ vector of `u16` values");
+impl_3d_vector!(F32x3, f32, "3-dimensional XYZ vector of `f32` values");
+
+impl From<I8x3> for F32x3 {
+    fn from(vector: I8x3) -> F32x3 {
+        F32x3::new(vector.x.into(), vector.y.into(), vector.z.into())
+    }
+}
+
+impl From<I16x3> for F32x3 {
+    fn from(vector: I16x3) -> F32x3 {
+        F32x3::new(vector.x.into(), vector.y.into(), vector.z.into())
+    }
+}
+
+impl From<U8x3> for F32x3 {
+    fn from(vector: U8x3) -> F32x3 {
+        F32x3::new(vector.x.into(), vector.y.into(), vector.z.into())
+    }
+}
+
+impl From<U16x3> for F32x3 {
+    fn from(vector: U16x3) -> F32x3 {
+        F32x3::new(vector.x.into(), vector.y.into(), vector.z.into())
+    }
+}


### PR DESCRIPTION
Adds the following vector types, whose names are common convention within the Rust embedded space:

### 2D vectors

- `I8x2`
- `I16x2`
- `U8x2`
- `U16x2`
- `F32x2`

### 3D vectors

- `I8x3`
- `I16x3`
- `U8x3`
- `U16x3`
- `F32x3`