### PR TITLE
f32ext: ceil(x) and floor(x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://raw.githubusercontent.com/NeoBirth/micromath/develop/img/micromath.png" width="640" height="320">
+# <img src="https://raw.githubusercontent.com/NeoBirth/micromath/develop/img/micromath.png" width="640">
 
 [![Crate][crate-img]][crate-link]
 [![Docs][docs-img]][docs-link]
@@ -33,8 +33,8 @@ analysis.
     - [ ] `tan`
   - `std` polyfills:
     - [x] [abs]
-    - [ ] `ceil`
-    - [ ] `floor`
+    - [x] [ceil]
+    - [x] [floor]
     - [ ] `round`
     - [ ] `trunc`
 - Algebraic vector types:
@@ -123,6 +123,8 @@ Apache 2.0 and MIT licenses.
 [atan2]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.atan2
 [sqrt]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.sqrt
 [abs]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.abs
+[ceil]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.ceil
+[floor]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.floor
 [I8x2]: https://docs.rs/micromath/latest/micromath/vector/struct.I8x2.html
 [I16x2]: https://docs.rs/micromath/latest/micromath/vector/struct.I16x2.html
 [U8x2]: https://docs.rs/micromath/latest/micromath/vector/struct.U8x2.html

--- a/src/f32ext.rs
+++ b/src/f32ext.rs
@@ -1,16 +1,17 @@
-/// `f32` extension providing various arithmetic approximations and polyfills
-/// for `std` functionality.
+//! `f32` extension providing various arithmetic approximations and polyfills
+//! for `std` functionality.
+
 mod abs;
 mod atan;
 mod atan2;
+mod ceil;
+mod floor;
 mod sqrt;
 
 /// `f32` extension providing various arithmetic approximations and polyfills
 /// for `std` functionality.
 pub trait F32Ext: Sized {
     /// Compute absolute value.
-    ///
-    /// Provides a constant-time, data-independent implementation.
     fn abs(self) -> f32;
 
     /// Computes an `atan` approximation in radians.
@@ -26,6 +27,12 @@ pub trait F32Ext: Sized {
     /// Approximates the four quadrant arctangent.
     /// Normalized to the `[0,4)` range with a maximum error of `0.1620` degrees.
     fn atan2_norm(self, other: f32) -> f32;
+
+    /// Approximates floating point ceiling.
+    fn ceil(self) -> f32;
+
+    /// Approximates floating point floor.
+    fn floor(self) -> f32;
 
     /// Compute square root
     fn sqrt(self) -> f32;
@@ -50,6 +57,14 @@ impl F32Ext for f32 {
 
     fn atan2_norm(self, other: f32) -> f32 {
         self::atan2::atan2_norm_approx(self, other)
+    }
+
+    fn ceil(self) -> f32 {
+        self::ceil::ceil(self)
+    }
+
+    fn floor(self) -> f32 {
+        self::floor::floor(self)
     }
 
     fn sqrt(self) -> f32 {

--- a/src/f32ext/abs.rs
+++ b/src/f32ext/abs.rs
@@ -1,5 +1,7 @@
 /// Compute the absolute value of `n`
 /// Method described at: <https://bits.stephan-brumme.com/absFloat.html>
+///
+/// Constant-time, data-independent implementation.
 pub(super) fn abs(n: f32) -> f32 {
     f32::from_bits(n.to_bits() & 0x7FFF_FFFF)
 }

--- a/src/f32ext/ceil.rs
+++ b/src/f32ext/ceil.rs
@@ -1,0 +1,21 @@
+use super::floor::floor;
+
+/// Floating point ceiling approximation for a single-precision float
+pub(super) fn ceil(x: f32) -> f32 {
+    -floor(-x)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanity_check() {
+        assert_eq!(ceil(-1.1), -1.0);
+        assert_eq!(ceil(-0.1), 0.0);
+        assert_eq!(ceil(0.0), 0.0);
+        assert_eq!(ceil(1.0), 1.0);
+        assert_eq!(ceil(1.1), 2.0);
+        assert_eq!(ceil(2.9), 3.0);
+    }
+}

--- a/src/f32ext/floor.rs
+++ b/src/f32ext/floor.rs
@@ -1,0 +1,25 @@
+/// Floating point floor approximation for a single-precision float.
+pub(super) fn floor(x: f32) -> f32 {
+    let mut x_trunc = (x as i32) as f32;
+
+    if x < x_trunc {
+        x_trunc -= 1.0;
+    }
+
+    x_trunc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanity_check() {
+        assert_eq!(floor(-1.1), -2.0);
+        assert_eq!(floor(-0.1), -1.0);
+        assert_eq!(floor(0.0), 0.0);
+        assert_eq!(floor(1.0), 1.0);
+        assert_eq!(floor(1.1), 1.0);
+        assert_eq!(floor(2.9), 2.0);
+    }
+}


### PR DESCRIPTION
Implements `floor(x)` by truncating and comparing if the truncated version is smaller.

Implements `ceil(x)` in terms of `floor(x)`.