### PR TITLE
f32ext: tan(x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ analysis.
     - [ ] `powf`
     - [x] [sin]
     - [x] [sqrt]
-    - [ ] `tan`
+    - [ ] [tan]
   - `std` polyfills:
     - [x] [abs]
     - [x] [ceil]
@@ -122,9 +122,10 @@ Apache 2.0 and MIT licenses.
 [atan]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.atan
 [atan2]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.atan2
 [cos]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.cos
-[invsqrt] https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.invsqrt
+[invsqrt]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.invsqrt
 [sin]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.sin
 [sqrt]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.sqrt
+[tan]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.tan
 [abs]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.abs
 [ceil]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.ceil
 [floor]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.floor

--- a/src/f32ext.rs
+++ b/src/f32ext.rs
@@ -10,6 +10,7 @@ mod floor;
 mod invsqrt;
 mod sin;
 mod sqrt;
+mod tan;
 
 /// `f32` extension providing various arithmetic approximations and polyfills
 /// for `std` functionality.
@@ -48,6 +49,9 @@ pub trait F32Ext: Sized {
 
     /// Approximates square root.
     fn sqrt(self) -> f32;
+
+    /// Approximates `tan(x)` in radians.
+    fn tan(self) -> f32;
 }
 
 impl F32Ext for f32 {
@@ -93,5 +97,9 @@ impl F32Ext for f32 {
 
     fn sqrt(self) -> f32 {
         self::sqrt::sqrt_approx(self)
+    }
+
+    fn tan(self) -> f32 {
+        self::tan::tan_approx(self)
     }
 }

--- a/src/f32ext/atan.rs
+++ b/src/f32ext/atan.rs
@@ -4,11 +4,11 @@
 //! <https://ieeexplore.ieee.org/document/6375931>
 
 use super::abs::abs;
-use core::f32::consts::PI;
+use core::f32;
 
-/// Computes an `atan` approximation in radians.
+/// Computes an `atan(x)` approximation in radians.
 pub(super) fn atan_approx(x: f32) -> f32 {
-    PI / 2.0 * atan_norm_approx(x)
+    f32::consts::FRAC_PI_2 * atan_norm_approx(x)
 }
 
 /// Approximates `atan(x)` normalized to the `[−1,1]` range with a maximum
@@ -39,16 +39,17 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-        for (x, expected) in [
+        // Arctangent test vectors - `(input, output)`
+        let test_vectors: &[(f32, f32)] = &[
             (3.0_f32.sqrt() / 3.0, f32::consts::FRAC_PI_6),
             (1.0, f32::consts::FRAC_PI_4),
             (3.0_f32.sqrt(), f32::consts::FRAC_PI_3),
             (-3.0_f32.sqrt() / 3.0, -f32::consts::FRAC_PI_6),
             (-1.0, -f32::consts::FRAC_PI_4),
             (-3.0_f32.sqrt(), -f32::consts::FRAC_PI_3),
-        ]
-        .iter()
-        {
+        ];
+
+        for (x, expected) in test_vectors {
             let actual = atan_approx(*x);
             let delta = actual - expected;
 

--- a/src/f32ext/atan2.rs
+++ b/src/f32ext/atan2.rs
@@ -6,7 +6,7 @@
 use super::abs::abs;
 use core::f32::consts::PI;
 
-/// Computes an `atan2` approximation in radians.
+/// Computes an `atan2(y,x)` approximation in radians.
 pub(super) fn atan2_approx(y: f32, x: f32) -> f32 {
     let n = atan2_norm_approx(y, x);
     PI / 2.0 * if n > 2.0 { n - 4.0 } else { n }
@@ -45,7 +45,7 @@ mod tests {
 
     #[test]
     fn sanity_check() {
-        let atan2_test_vectors = [
+        let test_vectors: &[(f32, f32, f32)] = &[
             (0.0, 1.0, 0.0),
             (0.0, -1.0, PI),
             (3.0, 2.0, (3.0f32 / 2.0).atan()),
@@ -53,7 +53,7 @@ mod tests {
             (-2.0, -1.0, (-2.0f32 / -1.0).atan() - PI),
         ];
 
-        for (y, x, expected) in &atan2_test_vectors {
+        for (y, x, expected) in test_vectors {
             let actual = atan2_approx(*y, *x);
             let delta = actual - expected;
 

--- a/src/f32ext/cos.rs
+++ b/src/f32ext/cos.rs
@@ -3,25 +3,25 @@
 
 use super::abs::abs;
 use super::floor::floor;
-use core::f32::consts::PI;
-
-const TP: f32 = 1.0 / (2.0 * PI);
+use core::f32;
 
 /// Approximates `cos(x)` in radians with a maximum error of `0.06`
 pub(super) fn cos_approx(mut x: f32) -> f32 {
-    x *= TP;
+    x *= f32::consts::FRAC_1_PI / 2.0;
     x -= 0.25 + floor(x + 0.25);
-    x * 16.0 * (abs(x) - 0.5)
+    x *= 16.0 * (abs(x) - 0.5);
+    x += 0.225 * x * (abs(x) - 1.0);
+    x
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
     use super::{abs, cos_approx};
 
     /// Maximum error in radians
-    const MAX_ERROR: f32 = 0.06;
+    pub(crate) const MAX_ERROR: f32 = 0.002;
 
-    /// Cosine test vectors `(input, output)`
+    /// Cosine test vectors - `(input, output)`
     const TEST_VECTORS: &[(f32, f32)] = &[
         (0.000, 1.000),
         (0.140, 0.990),

--- a/src/f32ext/sin.rs
+++ b/src/f32ext/sin.rs
@@ -11,10 +11,7 @@ pub(super) fn sin_approx(x: f32) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::sin_approx;
-    use crate::f32ext::abs::abs;
-
-    /// Maximum error in radians
-    const MAX_ERROR: f32 = 0.06;
+    use crate::f32ext::{abs::abs, cos::tests::MAX_ERROR};
 
     /// Sine test vectors - `(input, output)`
     const TEST_VECTORS: &[(f32, f32)] = &[

--- a/src/f32ext/sqrt.rs
+++ b/src/f32ext/sqrt.rs
@@ -11,7 +11,7 @@ pub(super) mod tests {
     /// Maximum error as a percentage of the input value (5%)
     pub(crate) const MAX_ERROR: f32 = 0.05;
 
-    /// Square root test vectors
+    /// Square root test vectors - `(input, output)`
     pub(crate) const TEST_VECTORS: &[(f32, f32)] = &[
         (1.0, 1.0),
         (2.0, 1.414),

--- a/src/f32ext/tan.rs
+++ b/src/f32ext/tan.rs
@@ -1,0 +1,93 @@
+//! Tangent approximation for a single-precision float.
+
+use super::{cos::cos_approx, sin::sin_approx};
+
+/// Computes `tan(x)` approximation in radians.
+pub(super) fn tan_approx(x: f32) -> f32 {
+    sin_approx(x) / cos_approx(x)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tan_approx;
+    use crate::f32ext::abs::abs;
+
+    /// Maximum error in radians
+    const MAX_ERROR: f32 = 0.6;
+
+    /// Tangent test vectors - `(input, output)`
+    const TEST_VECTORS: &[(f32, f32)] = &[
+        (0.000, 0.000),
+        (0.140, 0.141),
+        (0.279, 0.287),
+        (0.419, 0.445),
+        (0.559, 0.625),
+        (0.698, 0.839),
+        (0.838, 1.111),
+        (0.977, 1.483),
+        (1.117, 2.050),
+        (1.257, 3.078),
+        (1.396, 5.671),
+        (1.536, 28.636),
+        (1.676, -9.514),
+        (1.815, -4.011),
+        (1.955, -2.475),
+        (2.094, -1.732),
+        (2.234, -1.280),
+        (2.374, -0.966),
+        (2.513, -0.727),
+        (2.653, -0.532),
+        (2.793, -0.364),
+        (2.932, -0.213),
+        (3.072, -0.070),
+        (3.211, 0.070),
+        (3.351, 0.213),
+        (3.491, 0.364),
+        (3.630, 0.532),
+        (3.770, 0.727),
+        (3.910, 0.966),
+        (4.049, 1.280),
+        (4.189, 1.732),
+        (4.328, 2.475),
+        (4.468, 4.011),
+        (4.608, 9.514),
+        (4.747, -28.636),
+        (4.887, -5.671),
+        (5.027, -3.078),
+        (5.166, -2.050),
+        (5.306, -1.483),
+        (5.445, -1.111),
+        (5.585, -0.839),
+        (5.725, -0.625),
+        (5.864, -0.445),
+        (6.004, -0.287),
+        (6.144, -0.141),
+        (6.283, 0.000),
+    ];
+
+    #[test]
+    fn sanity_check() {
+        for (x, expected) in TEST_VECTORS {
+            let tan_x = tan_approx(*x);
+            let delta = abs(tan_x - expected);
+
+            assert!(
+                delta <= MAX_ERROR,
+                "delta {} too large: {} vs {}",
+                delta,
+                tan_x,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn zero() {
+        assert_eq!(tan_approx(0.0), 0.0);
+    }
+
+    #[test]
+    fn nan() {
+        assert!(tan_approx(core::f32::NAN).is_nan());
+    }
+}


### PR DESCRIPTION
Implements tangent in terms of `sin` and `cos`.

Note that `sin` is implemented in terms of `cos`, so this ultimately implements it in terms of the cosine function alone.

In order to get decent precision (`~0.6` radians, which is difficult for larger tangent values) this commit includes modifications to `cos` to increase the precision of its approximation.