### PR TITLE
vector: Add i32 and u32 vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ analysis.
   - 2D:
     - [x] [I8x2]
     - [x] [I16x2]
-    - [ ] `I32x2`
+    - [x] [I32x2]
     - [x] [U8x2]
     - [x] [U16x2]
-    - [ ] `U32x2`
+    - [x] [U32x2]
     - [x] [F32x2]
   - 3D:
     - [x] [I8x3]
     - [x] [I16x3]
-    - [ ] `I32x3`
+    - [x] [I32x3]
     - [x] [U8x3]
     - [x] [U16x3]
-    - [ ] `U32x3`
+    - [x] [U32x3]
     - [x] [F32x3]
 - Statistical analysis:
   - [x] [mean]
@@ -105,7 +105,7 @@ Dual licensed under your choice of either of:
 - Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 - MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
-Incorporates some tests from the [libm crate], which is
+Incorporates portions of some tests from the [libm crate].
 Copyright © 2018 Jorge Aparicio and also dual licensed under the
 Apache 2.0 and MIT licenses. 
 
@@ -131,13 +131,17 @@ Apache 2.0 and MIT licenses.
 [floor]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.floor
 [I8x2]: https://docs.rs/micromath/latest/micromath/vector/struct.I8x2.html
 [I16x2]: https://docs.rs/micromath/latest/micromath/vector/struct.I16x2.html
+[I32x2]: https://docs.rs/micromath/latest/micromath/vector/struct.I32x2.html
 [U8x2]: https://docs.rs/micromath/latest/micromath/vector/struct.U8x2.html
 [U16x2]: https://docs.rs/micromath/latest/micromath/vector/struct.U16x2.html
+[U32x2]: https://docs.rs/micromath/latest/micromath/vector/struct.U32x2.html
 [F32x2]: https://docs.rs/micromath/latest/micromath/vector/struct.F32x2.html
 [I8x3]: https://docs.rs/micromath/latest/micromath/vector/struct.I8x3.html
-[I16x3]: https://docs.rs/micromath/latest/micromath/vector/struct.I8x3.html
+[I16x3]: https://docs.rs/micromath/latest/micromath/vector/struct.I16x3.html
+[I32x3]: https://docs.rs/micromath/latest/micromath/vector/struct.I32x3.html
 [U8x3]: https://docs.rs/micromath/latest/micromath/vector/struct.U8x3.html
 [U16x3]: https://docs.rs/micromath/latest/micromath/vector/struct.U16x3.html
+[U32x3]: https://docs.rs/micromath/latest/micromath/vector/struct.U32x3.html
 [F32x3]: https://docs.rs/micromath/latest/micromath/vector/struct.F32x3.html
 [mean]: https://docs.rs/micromath/latest/micromath/statistics/trait.Mean.html
 [variance]: https://docs.rs/micromath/latest/micromath/statistics/trait.Variance.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,3 +57,5 @@ pub mod vector;
 
 pub use f32ext::F32Ext;
 pub use generic_array;
+#[cfg(feature = "vector")]
+pub use vector::{Vector, VectorExt};

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -16,14 +16,12 @@ mod xyz;
 pub use self::{component::*, iter::*, xy::*, xyz::*};
 
 /// Vectors with numeric components
-pub trait Vector:
-    Copy + Debug + Default + Index<usize> + MulAssign<f32> + PartialEq + Sized + Send + Sync
-{
-    /// Type representing measured acceleration for a particular axis
-    type Component: Component;
-
+pub trait Vector: Copy + Debug + Default + Index<usize> + PartialEq + Sized + Send + Sync {
     /// Number of axes
     type Axes: ArrayLength<Self::Component>;
+
+    /// Type representing measured acceleration for a particular axis
+    type Component: Component;
 
     /// Smallest value representable by a vector component
     const MIN: Self::Component;
@@ -53,6 +51,26 @@ pub trait Vector:
         Iter::new(self)
     }
 
+    /// Obtain an array of the acceleration components for each of the axes
+    fn to_array(self) -> GenericArray<Self::Component, Self::Axes>;
+}
+
+/// Vector geometry extensions usable on vectors whose components can be
+/// converted into `f32`.
+pub trait VectorExt: Vector + MulAssign<f32> {
+    /// Compute the distance between two vectors
+    fn distance(self, other: Self) -> f32;
+
+    /// Compute the magnitude of a vector
+    fn magnitude(self) -> f32;
+}
+
+impl<V, A, C> VectorExt for V
+where
+    V: Vector<Axes = A, Component = C> + MulAssign<f32>,
+    A: ArrayLength<C>,
+    C: Component + Into<f32>,
+{
     /// Compute the distance between two vectors
     fn distance(self, other: Self) -> f32 {
         let differences = self
@@ -73,7 +91,4 @@ pub trait Vector:
             .sum::<f32>()
             .sqrt()
     }
-
-    /// Obtain an array of the acceleration components for each of the axes
-    fn to_array(self) -> GenericArray<Self::Component, Self::Axes>;
 }

--- a/src/vector/component.rs
+++ b/src/vector/component.rs
@@ -13,14 +13,13 @@ pub trait Component:
     + Div<Output = Self>
     + PartialOrd
     + PartialEq
-    + Into<f32>
 {
 }
 
 impl Component for i8 {}
 impl Component for i16 {}
-// TODO: impl Component for i32 {}
+impl Component for i32 {}
 impl Component for u8 {}
 impl Component for u16 {}
-// TODO: impl Component for u32 {}
+impl Component for u32 {}
 impl Component for f32 {}

--- a/src/vector/xy.rs
+++ b/src/vector/xy.rs
@@ -73,6 +73,12 @@ macro_rules! impl_2d_vector {
                 }
             }
         }
+    }
+}
+
+macro_rules! impl_2d_vector_ext {
+    ($vector:ident, $component:tt, $doc:expr) => {
+        impl_2d_vector!($vector, $component, $doc);
 
         impl MulAssign<f32> for $vector {
             #[allow(trivial_numeric_casts)]
@@ -81,16 +87,16 @@ macro_rules! impl_2d_vector {
                 self.y = (f32::from(self.y) * n) as $component;
             }
         }
-    }
+    };
 }
 
-impl_2d_vector!(I8x2, i8, "2-dimensional XY vector of `i8` values");
-impl_2d_vector!(I16x2, i16, "2-dimensional XY vector of `i16` values");
-// TODO: impl_2d_vector!(I32x2, i32, "2-dimensional XY vector of `i32` values");
-impl_2d_vector!(U8x2, u8, "2-dimensional XY vector of `u8` values");
-impl_2d_vector!(U16x2, u16, "2-dimensional XY vector of `u16` values");
-// TODO: impl_2d_vector!(U32x2, u32, "2-dimensional XY vector of `u32` values");
-impl_2d_vector!(F32x2, f32, "2-dimensional XY vector of `f32` values");
+impl_2d_vector_ext!(I8x2, i8, "2-dimensional XY vector of `i8` values");
+impl_2d_vector_ext!(I16x2, i16, "2-dimensional XY vector of `i16` values");
+impl_2d_vector!(I32x2, i32, "2-dimensional XY vector of `i32` values");
+impl_2d_vector_ext!(U8x2, u8, "2-dimensional XY vector of `u8` values");
+impl_2d_vector_ext!(U16x2, u16, "2-dimensional XY vector of `u16` values");
+impl_2d_vector!(U32x2, u32, "2-dimensional XY vector of `u32` values");
+impl_2d_vector_ext!(F32x2, f32, "2-dimensional XY vector of `f32` values");
 
 impl MulAssign<i8> for I8x2 {
     fn mul_assign(&mut self, n: i8) {

--- a/src/vector/xyz.rs
+++ b/src/vector/xyz.rs
@@ -78,6 +78,12 @@ macro_rules! impl_3d_vector {
                 }
             }
         }
+    }
+}
+
+macro_rules! impl_3d_vector_ext {
+    ($vector:ident, $component:tt, $doc:expr) => {
+        impl_3d_vector!($vector, $component, $doc);
 
         impl MulAssign<f32> for $vector {
             #[allow(trivial_numeric_casts)]
@@ -87,16 +93,16 @@ macro_rules! impl_3d_vector {
                 self.z = (f32::from(self.z) * n) as $component;
             }
         }
-    }
+    };
 }
 
-impl_3d_vector!(I8x3, i8, "3-dimensional XYZ vector of `i8` values");
-impl_3d_vector!(I16x3, i16, "3-dimensional XYZ vector of `i16` values");
-// TODO: impl_3d_vector!(I32x3, i32, "3-dimensional XYZ vector of `i32` values");
-impl_3d_vector!(U8x3, u8, "3-dimensional XYZ vector of `u8` values");
-impl_3d_vector!(U16x3, u16, "3-dimensional XYZ vector of `u16` values");
-// TODO: impl_3d_vector!(U32x3, u32, "3-dimensional XYZ vector of `u16` values");
-impl_3d_vector!(F32x3, f32, "3-dimensional XYZ vector of `f32` values");
+impl_3d_vector_ext!(I8x3, i8, "3-dimensional XYZ vector of `i8` values");
+impl_3d_vector_ext!(I16x3, i16, "3-dimensional XYZ vector of `i16` values");
+impl_3d_vector!(I32x3, i32, "3-dimensional XYZ vector of `i32` values");
+impl_3d_vector_ext!(U8x3, u8, "3-dimensional XYZ vector of `u8` values");
+impl_3d_vector_ext!(U16x3, u16, "3-dimensional XYZ vector of `u16` values");
+impl_3d_vector!(U32x3, u32, "3-dimensional XYZ vector of `u16` values");
+impl_3d_vector_ext!(F32x3, f32, "3-dimensional XYZ vector of `f32` values");
 
 impl From<I8x3> for F32x3 {
     fn from(vector: I8x3) -> F32x3 {


### PR DESCRIPTION
Splits the functionality that depends on `Vector::Component` being `Into<f32>` into a separate `VectorExt` (maybe not the greatest name) trait, so that all vectors aren't constrained by it.

This allows adding the following vector types:

- `I32x2`, `I32x3`
- `U32x2`, `U32x3`