### PR TITLE
f32ext: Better document maximum errors/precision

### DIFF
--- a/src/f32ext.rs
+++ b/src/f32ext.rs
@@ -15,17 +15,19 @@ mod tan;
 /// `f32` extension providing various arithmetic approximations and polyfills
 /// for `std` functionality.
 pub trait F32Ext: Sized {
-    /// Compute absolute value.
+    /// Compute absolute value with a constant-time, data-independent
+    /// implementation.
     fn abs(self) -> f32;
 
-    /// Approximates `atan(x)` in radians.
+    /// Approximates `atan(x)` in radians with a maximum error of `0.002`.
     fn atan(self) -> f32;
 
     /// Approximates `atan(x)` normalized to the `[−1,1]` range with a maximum
     /// error of `0.1620` degrees.
     fn atan_norm(self) -> f32;
 
-    /// Approximates the four quadrant arctangent `atan2(x)`.
+    /// Approximates the four quadrant arctangent `atan2(x)` in radians, with
+    /// a maximum error of `0.002`.
     fn atan2(self, other: f32) -> f32;
 
     /// Approximates the four quadrant arctangent.
@@ -35,7 +37,7 @@ pub trait F32Ext: Sized {
     /// Approximates floating point ceiling.
     fn ceil(self) -> f32;
 
-    /// Approximates cosine in radians.
+    /// Approximates cosine in radians with a maximum error of `0.002`.
     fn cos(self) -> f32;
 
     /// Approximates floating point floor.
@@ -44,13 +46,13 @@ pub trait F32Ext: Sized {
     /// Approximates inverse square root.
     fn invsqrt(self) -> f32;
 
-    /// Approximates sine in radians.
+    /// Approximates sine in radians with a maximum error of `0.002`.
     fn sin(self) -> f32;
 
-    /// Approximates square root.
+    /// Approximates square root with an average deviation of ~5%.
     fn sqrt(self) -> f32;
 
-    /// Approximates `tan(x)` in radians.
+    /// Approximates `tan(x)` in radians with a maximum error of `0.6`.
     fn tan(self) -> f32;
 }
 

--- a/src/f32ext/cos.rs
+++ b/src/f32ext/cos.rs
@@ -5,7 +5,7 @@ use super::abs::abs;
 use super::floor::floor;
 use core::f32;
 
-/// Approximates `cos(x)` in radians with a maximum error of `0.06`
+/// Approximates `cos(x)` in radians with a maximum error of `0.002`
 pub(super) fn cos_approx(mut x: f32) -> f32 {
     x *= f32::consts::FRAC_1_PI / 2.0;
     x -= 0.25 + floor(x + 0.25);

--- a/src/f32ext/sin.rs
+++ b/src/f32ext/sin.rs
@@ -3,7 +3,7 @@
 use super::cos::cos_approx;
 use core::f32::consts::PI;
 
-/// Approximates `sin(x)` in radians with a maximum error of `0.06`
+/// Approximates `sin(x)` in radians with a maximum error of `0.002`
 pub(super) fn sin_approx(x: f32) -> f32 {
     cos_approx(x - PI / 2.0)
 }

--- a/src/f32ext/sqrt.rs
+++ b/src/f32ext/sqrt.rs
@@ -8,7 +8,7 @@ pub(super) fn sqrt_approx(x: f32) -> f32 {
 pub(super) mod tests {
     use super::sqrt_approx;
 
-    /// Maximum error as a percentage of the input value (5%)
+    /// Deviation from the actual value (5%)
     pub(crate) const MAX_ERROR: f32 = 0.05;
 
     /// Square root test vectors - `(input, output)`

--- a/src/f32ext/tan.rs
+++ b/src/f32ext/tan.rs
@@ -13,6 +13,7 @@ mod tests {
     use crate::f32ext::abs::abs;
 
     /// Maximum error in radians
+    // TODO(tarcieri): this is kinda bad, find a better approximation?
     const MAX_ERROR: f32 = 0.6;
 
     /// Tangent test vectors - `(input, output)`


### PR DESCRIPTION
Add information about the precision of all approximations so it will show up in the rustdoc