### PR TITLE
Quaternions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name        = "micromath"
 description = """
               Embedded math library featuring fast, safe floating point
               approximations for common arithmetic operations, 2D and 3D
-              vector types, and statistical analysis.
+              vector types, statistical analysis, and quaternions.
               """
 version     = "0.2.2" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
@@ -19,6 +19,7 @@ keywords    = ["math", "vector"]
 generic-array = { version = "0.13", default-features = false }
 
 [features]
-default = ["statistics", "vector"]
+default = ["quaternion", "statistics", "vector"]
+quaternion = []
 statistics = []
 vector = []

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![Gitter Chat][gitter-image]][gitter-link]
 
 Embedded Rust math library featuring fast, safe floating point approximations
-for common arithmetic operations, 2D and 3D vector types, and statistical
-analysis.
+for common arithmetic operations, 2D and 3D vector types, statistical analysis,
+and quaternions.
 
 [Documentation][docs-link]
 
@@ -59,8 +59,7 @@ analysis.
   - [x] [mean]
   - [x] [variance]
   - [x] [stddev]
-- Quaternions
-  - [ ] TBD
+- [Quaternions]
 
 ## Comparisons with other Rust crates
 
@@ -151,6 +150,7 @@ Apache 2.0 and MIT licenses.
 [mean]: https://docs.rs/micromath/latest/micromath/statistics/trait.Mean.html
 [variance]: https://docs.rs/micromath/latest/micromath/statistics/trait.Variance.html
 [stddev]: https://docs.rs/micromath/latest/micromath/statistics/trait.StdDev.html
+[Quaternions]: https://docs.rs/micromath/latest/micromath/quaternion/struct.Quaternion.html
 [libm crate]: https://github.com/rust-lang-nursery/libm
 [vek crate]: https://github.com/yoanlcq/vek
 [approx crate]: https://crates.io/crates/approx

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,14 @@
 //! - [StdDev] - compute standard deviation with the `stddev()` method
 //! - [Variance] - compute variance with the `variance() method
 //!
+//! ## Quaternions
+//!
+//! See the [`quaternion` module] for more information.
+//!
 //! [micromath::F32Ext]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html
 //! [`vector` module]: https://docs.rs/micromath/vector/micromath/vector/index.html
 //! [`statistics` module]: https://docs.rs/micromath/latest/micromath/statistics/index.html
+//! [`quaternion` module]: https://docs.rs/micromath/latest/micromath/quaternion/index.html
 //! [Mean]: https://docs.rs/micromath/latest/micromath/statistics/trait.Mean.html
 //! [StdDev]: https://docs.rs/micromath/latest/micromath/statistics/trait.StdDev.html
 //! [Variance]: https://docs.rs/micromath/latest/micromath/statistics/trait.Variance.html
@@ -86,6 +91,8 @@
 )]
 
 mod f32ext;
+#[cfg(feature = "quaternion")]
+pub mod quaternion;
 #[cfg(feature = "statistics")]
 pub mod statistics;
 #[cfg(feature = "vector")]
@@ -93,5 +100,7 @@ pub mod vector;
 
 pub use f32ext::F32Ext;
 pub use generic_array;
+#[cfg(feature = "quaternion")]
+pub use quaternion::Quaternion;
 #[cfg(feature = "vector")]
 pub use vector::{Vector, VectorExt};

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -1,0 +1,140 @@
+// Adapted from the madgwick crate: https://github.com/japaric/madgwick
+// Copyright (c) 2018 Jorge Aparicio
+//
+// Original sources dual licensed under your choice of the Apache 2.0
+// and/or MIT licenses, which matches this crate's licensing terms.
+//
+// See toplevel LICENSE-MIT for more information on the MIT license.
+// Apache 2.0 license follows:
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Quaternions are a number system that extends the complex numbers which can
+//! be used for efficiently computing spatial rotations.
+//!
+//! They are computed as the quotient of two directed lines in a
+//! three-dimensional space, or equivalently as the quotient of two vectors.
+//!
+//! For given real numbers `a`, `b`, `c`, and `d`, they take the form:
+//!
+//! `a + bi + cj + dk`
+//!
+//! where `i`, `j`, and `k` are the fundamental quaternion units:
+//!
+//! `i² = j² = k² = i*j*k = -1`
+//!
+//! Quaternion multiplication is noncommutative:
+//!
+//! | x | 1  | i  | j  | k  |
+//! |---|----|----|----|----|
+//! | 1 | 1  | i  | j  | k  |
+//! | i | i  | -1 | k  | -j |
+//! | j | j  | -k | -1 | i  |
+//! | k | k  | j  | -i | -1 |
+
+use core::ops::{AddAssign, Mul, MulAssign, SubAssign};
+
+/// Quaternion
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Quaternion(pub f32, pub f32, pub f32, pub f32);
+
+impl Quaternion {
+    /// Returns the conjugate of this quaternion
+    pub fn conj(self) -> Self {
+        Quaternion(self.0, -self.1, -self.2, -self.3)
+    }
+
+    /// Returns the norm of this quaternion
+    pub fn norm(self) -> f32 {
+        self.0 * self.0 + self.1 * self.1 + self.2 * self.2 + self.3 * self.3
+    }
+}
+
+impl AddAssign<Quaternion> for Quaternion {
+    fn add_assign(&mut self, rhs: Quaternion) {
+        self.0 += rhs.0;
+        self.1 += rhs.1;
+        self.2 += rhs.2;
+        self.3 += rhs.3;
+    }
+}
+
+impl MulAssign<f32> for Quaternion {
+    fn mul_assign(&mut self, k: f32) {
+        self.0 *= k;
+        self.1 *= k;
+        self.2 *= k;
+        self.3 *= k;
+    }
+}
+
+impl SubAssign<Quaternion> for Quaternion {
+    fn sub_assign(&mut self, rhs: Quaternion) {
+        self.0 -= rhs.0;
+        self.1 -= rhs.1;
+        self.2 -= rhs.2;
+        self.3 -= rhs.3;
+    }
+}
+
+impl Mul<Quaternion> for Quaternion {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        Quaternion(
+            self.0 * other.0 - self.1 * other.1 - self.2 * other.2 - self.3 * other.3,
+            self.0 * other.1 + self.1 * other.0 + self.2 * other.3 - self.3 * other.2,
+            self.0 * other.2 - self.1 * other.3 + self.2 * other.0 + self.3 * other.1,
+            self.0 * other.3 + self.1 * other.2 - self.2 * other.1 + self.3 * other.0,
+        )
+    }
+}
+
+impl Mul<f32> for Quaternion {
+    type Output = Self;
+
+    fn mul(self, k: f32) -> Self {
+        Quaternion(self.0 * k, self.1 * k, self.2 * k, self.3 * k)
+    }
+}
+
+impl Mul<Quaternion> for f32 {
+    type Output = Quaternion;
+
+    fn mul(self, q: Quaternion) -> Quaternion {
+        q * self
+    }
+}
+
+#[cfg(tests)]
+mod tests {
+    // TODO: write test!
+    #[test]
+    fn add_assign() {}
+
+    // TODO: write test!
+    #[test]
+    fn mul_assign() {}
+
+    // TODO: write test!
+    #[test]
+    fn sub_assign() {}
+
+    // TODO: write test!
+    #[test]
+    fn mul_quaternion() {}
+
+    // TODO: write test!
+    #[test]
+    fn mul_f32() {}
+}

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1,4 +1,15 @@
-//! Statistical analysis support
+//! Statistical analysis support.
+//!
+//! The following traits are available and impl'd for slices and iterators of
+//! `f32` (and can be impl'd for other types):
+//!
+//! - [Mean] - compute arithmetic mean with the `mean()` method
+//! - [StdDev] - compute standard deviation with the `stddev()` method
+//! - [Variance] - compute variance with the `variance() method
+//!
+//! [Mean]: https://docs.rs/micromath/latest/micromath/statistics/trait.Mean.html
+//! [StdDev]: https://docs.rs/micromath/latest/micromath/statistics/trait.StdDev.html
+//! [Variance]: https://docs.rs/micromath/latest/micromath/statistics/trait.Variance.html
 
 mod mean;
 mod stddev;


### PR DESCRIPTION
Implementation vendored from the `madgwick` crate:

https://github.com/japaric/madgwick

Licensing information (Apache 2.0+MIT) duly noted.