### PR TITLE
Implement F32Ext::asin, ::acos, and ::hypot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,22 @@
 [package]
 name        = "micromath"
-description = """
-Embedded math library featuring fast, safe floating point
-approximations for common arithmetic operations, 2D and 3D
-vector types, statistical analysis, and quaternions.
-"""
 version     = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+description = """
+Embedded-friendly math library featuring fast floating point approximations
+(with small code size) for common arithmetic operations, triganometry,
+2D/3D vector types, statistical analysis, and quaternions.
+"""
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 repository  = "https://github.com/NeoBirth/micromath"
 readme      = "README.md"
 edition     = "2018"
 categories  = ["embedded", "science", "no-std"]
-keywords    = ["math", "vector"]
+keywords    = ["math", "quaternions", "statistics", "triganometry", "vector"]
 
-[dependencies]
-generic-array = { version = "0.13", default-features = false }
+[dependencies.generic-array]
+version = "0.13"
+default-features = false
 
 [features]
 default = ["quaternion", "statistics", "vector"]

--- a/README.md
+++ b/README.md
@@ -22,54 +22,54 @@ Optimizes for performance and small code size at the cost of precision.
 
 - [`f32` extension]:
   - Fast approximations:
-    - [ ] `asin`
-    - [ ] `acos`
-    - [x] [atan]
-    - [x] [atan2]
-    - [x] [cos]
-    - [ ] `hypot`
-    - [x] [inv]
-    - [x] [invsqrt]
-    - [x] [ln]
-    - [x] [log]
-    - [x] [log2]
-    - [x] [log10]
-    - [x] [powf]
-    - [x] [exp]
-    - [x] [sin]
-    - [x] [sqrt]
-    - [x] [tan]
+    - [asin]
+    - [acos]
+    - [atan]
+    - [atan2]
+    - [cos]
+    - [hypot]
+    - [inv]
+    - [invsqrt]
+    - [ln]
+    - [log]
+    - [log2]
+    - [log10]
+    - [powf]
+    - [exp]
+    - [sin]
+    - [sqrt]
+    - [tan]
   - `std` polyfills:
-    - [x] [abs]
-    - [x] [ceil]
-    - [x] [floor]
-    - [x] [round]
-    - [x] [trunc]
-    - [x] [fract]
-    - [x] [copysign]
+    - [abs]
+    - [ceil]
+    - [floor]
+    - [round]
+    - [trunc]
+    - [fract]
+    - [copysign]
 
 - [Algebraic vector types]:
   - 2D:
-    - [x] [I8x2]
-    - [x] [I16x2]
-    - [x] [I32x2]
-    - [x] [U8x2]
-    - [x] [U16x2]
-    - [x] [U32x2]
-    - [x] [F32x2]
+    - [I8x2]
+    - [I16x2]
+    - [I32x2]
+    - [U8x2]
+    - [U16x2]
+    - [U32x2]
+    - [F32x2]
   - 3D:
-    - [x] [I8x3]
-    - [x] [I16x3]
-    - [x] [I32x3]
-    - [x] [U8x3]
-    - [x] [U16x3]
-    - [x] [U32x3]
-    - [x] [F32x3]
+    - [I8x3]
+    - [I16x3]
+    - [I32x3]
+    - [U8x3]
+    - [U16x3]
+    - [U32x3]
+    - [F32x3]
 - [Statistical analysis]:
-  - [x] [mean]
-  - [x] [stddev]
-  - [x] [trim]
-  - [x] [variance]
+  - [mean]
+  - [stddev]
+  - [trim]
+  - [variance]
 - [Quaternions]
 
 ## Comparisons with other Rust crates
@@ -131,9 +131,12 @@ Apache 2.0 and MIT licenses.
 [gitter-image]: https://badges.gitter.im/NeoBirth/micromath.svg
 [gitter-link]: https://gitter.im/NeoBirth/community
 [`f32` extension]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html
+[asin]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.asin
+[acos]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.acos
 [atan]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.atan
 [atan2]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.atan2
 [cos]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.cos
+[hypot]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.hypot
 [inv]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.inv
 [invsqrt]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.invsqrt
 [ln]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.ln

--- a/src/f32ext.rs
+++ b/src/f32ext.rs
@@ -2,6 +2,8 @@
 //! for `std` functionality.
 
 mod abs;
+mod acos;
+mod asin;
 mod atan;
 mod atan2;
 mod ceil;
@@ -10,6 +12,7 @@ mod cos;
 mod exp;
 mod floor;
 mod fract;
+mod hypot;
 mod inv;
 mod invsqrt;
 mod ln;
@@ -31,74 +34,97 @@ pub trait F32Ext: Sized {
     /// implementation.
     fn abs(self) -> f32;
 
-    /// Approximates `atan(x)` in radians with a maximum error of `0.002`.
+    /// Approximate `asin(x)` in radians in the range `[-pi/2, pi/2]`.
+    fn asin(self) -> f32;
+
+    /// Approximate `acos(x)` in radians in the range `[0, pi]`
+    fn acos(self) -> f32;
+
+    /// Approximate `atan(x)` in radians with a maximum error of `0.002`.
     fn atan(self) -> f32;
 
-    /// Approximates `atan(x)` normalized to the `[−1,1]` range with a maximum
+    /// Approximate `atan(x)` normalized to the `[−1,1]` range with a maximum
     /// error of `0.1620` degrees.
     fn atan_norm(self) -> f32;
 
-    /// Approximates the four quadrant arctangent `atan2(x)` in radians, with
+    /// Approximate the four quadrant arctangent `atan2(x)` in radians, with
     /// a maximum error of `0.002`.
     fn atan2(self, other: f32) -> f32;
 
-    /// Approximates the four quadrant arctangent.
+    /// Approximate the four quadrant arctangent.
     /// Normalized to the `[0,4)` range with a maximum error of `0.1620` degrees.
     fn atan2_norm(self, other: f32) -> f32;
 
-    /// Approximates floating point ceiling.
+    /// Approximate floating point ceiling.
     fn ceil(self) -> f32;
 
-    /// Approximates cosine in radians with a maximum error of `0.002`.
+    /// Approximate cosine in radians with a maximum error of `0.002`.
     fn cos(self) -> f32;
 
-    /// Approximates floating point floor.
+    /// Approximate floating point floor.
     fn floor(self) -> f32;
 
-    /// Approximates `1/x` with an average deviation of ~8%.
+    /// Approximate the length of the hypotenuse of a right-angle triangle given
+    /// legs of length `x` and `y`.
+    fn hypot(self, other: f32) -> f32;
+
+    /// Approximate `1/x` with an average deviation of ~8%.
     fn inv(self) -> f32;
 
-    /// Approximates inverse square root with an average deviation of ~5%.
+    /// Approximate inverse square root with an average deviation of ~5%.
     fn invsqrt(self) -> f32;
 
-    /// Approximates sine in radians with a maximum error of `0.002`.
+    /// Approximate sine in radians with a maximum error of `0.002`.
     fn sin(self) -> f32;
 
-    /// Approximates square root with an average deviation of ~5%.
+    /// Approximate square root with an average deviation of ~5%.
     fn sqrt(self) -> f32;
 
-    /// Approximates `tan(x)` in radians with a maximum error of `0.6`.
+    /// Approximate `tan(x)` in radians with a maximum error of `0.6`.
     fn tan(self) -> f32;
 
-    /// retrieves whole number part of floating point with sign
+    /// Retrieve whole number part of floating point with sign.
     fn trunc(self) -> f32;
 
-    /// rounds the number part of floating point with sign
+    /// Round the number part of floating point with sign.
     fn round(self) -> f32;
 
-    /// retrieves the fractional part of floating point with sign
+    /// Retrieve the fractional part of floating point with sign.
     fn fract(self) -> f32;
 
-    /// copies the sign from one number to another and returns it.
+    /// Copies the sign from one number to another and returns it.
     fn copysign(self, sign: f32) -> f32;
-    /// approximates ln(x)
+
+    /// Approximate `ln(x)`.
     fn ln(self) -> f32;
 
-    ///approximates e^x
+    /// Approximate `e^x`.
     fn exp(self) -> f32;
-    ///approximates log to an arbitrary base
+
+    /// Approximate `log` with an arbitrary base.
     fn log(self, base: f32) -> f32;
-    ///approximates log2
+
+    /// Approximate `log2`.
     fn log2(self) -> f32;
-    ///approximates log10
+
+    /// Approximate `log10`.
     fn log10(self) -> f32;
-    ///approximates self^n
+
+    /// Approximate `self^n`.
     fn powf(self, n: f32) -> f32;
 }
 
 impl F32Ext for f32 {
     fn abs(self) -> f32 {
         self::abs::abs(self)
+    }
+
+    fn asin(self) -> f32 {
+        self::asin::asin_approx(self)
+    }
+
+    fn acos(self) -> f32 {
+        self::acos::acos_approx(self)
     }
 
     fn atan(self) -> f32 {
@@ -117,10 +143,6 @@ impl F32Ext for f32 {
         self::atan2::atan2_norm_approx(self, other)
     }
 
-    fn round(self) -> f32 {
-        self::round::round(self)
-    }
-
     fn ceil(self) -> f32 {
         self::ceil::ceil(self)
     }
@@ -131,6 +153,10 @@ impl F32Ext for f32 {
 
     fn floor(self) -> f32 {
         self::floor::floor(self)
+    }
+
+    fn hypot(self, other: f32) -> f32 {
+        self::hypot::hypot_approx(self, other)
     }
 
     fn inv(self) -> f32 {
@@ -155,6 +181,10 @@ impl F32Ext for f32 {
 
     fn trunc(self) -> f32 {
         self::trunc::trunc_sign(self)
+    }
+
+    fn round(self) -> f32 {
+        self::round::round(self)
     }
 
     fn fract(self) -> f32 {

--- a/src/f32ext/acos.rs
+++ b/src/f32ext/acos.rs
@@ -1,0 +1,27 @@
+//! arccos approximation for a single-precision float using method
+//! described at:
+//!
+//! <https://math.stackexchange.com/questions/2908908/express-arccos-in-terms-of-arctan>
+
+use super::{atan::atan_approx, sqrt::sqrt_approx};
+
+/// Computes `acos(x)` approximation in radians in the range `[0, pi]`
+pub(super) fn acos_approx(x: f32) -> f32 {
+    atan_approx(sqrt_approx(1.0 - x * x) / x)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::acos_approx;
+    use crate::f32ext::{abs::abs, cos::cos_approx};
+    use core::f32;
+
+    const MAX_ERROR: f32 = 0.03;
+
+    #[test]
+    fn sanity_check() {
+        let f = f32::consts::FRAC_PI_4;
+        let abs_difference = abs(acos_approx(cos_approx(f)) - f32::consts::FRAC_PI_4);
+        assert!(abs_difference <= MAX_ERROR);
+    }
+}

--- a/src/f32ext/asin.rs
+++ b/src/f32ext/asin.rs
@@ -1,0 +1,25 @@
+//! arcsin approximation for a single-precision float using method
+//! described at:
+//!
+//! <https://dsp.stackexchange.com/questions/25770/looking-for-an-arcsin-algorithm>
+
+use super::{atan::atan_approx, invsqrt::invsqrt_approx};
+
+/// Computes `asin(x)` approximation in radians in the range `[-pi/2, pi/2]`.
+pub(super) fn asin_approx(x: f32) -> f32 {
+    atan_approx(x * invsqrt_approx(1.0 - x * x))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::asin_approx;
+    use crate::f32ext::{abs::abs, sin::sin_approx};
+    use core::f32;
+
+    #[test]
+    fn sanity_check() {
+        let f = f32::consts::FRAC_PI_2;
+        let abs_difference = abs(asin_approx(sin_approx(f)) - f32::consts::FRAC_PI_2);
+        assert!(abs_difference <= f32::EPSILON);
+    }
+}

--- a/src/f32ext/atan.rs
+++ b/src/f32ext/atan.rs
@@ -6,7 +6,7 @@
 use super::abs::abs;
 use core::f32;
 
-/// Computes an `atan(x)` approximation in radians.
+/// Computes `atan(x)` approximation in radians.
 pub(super) fn atan_approx(x: f32) -> f32 {
     f32::consts::FRAC_PI_2 * atan_norm_approx(x)
 }

--- a/src/f32ext/hypot.rs
+++ b/src/f32ext/hypot.rs
@@ -1,0 +1,24 @@
+//! Calculate length of the hypotenuse of a right triangle
+
+use super::sqrt::sqrt_approx;
+
+/// Calculate the length of the hypotenuse of a right-angle triangle given
+/// legs of length `x` and `y`.
+pub(super) fn hypot_approx(x: f32, y: f32) -> f32 {
+    sqrt_approx(x * x + y * y)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{hypot_approx, sqrt_approx};
+    use crate::f32ext::abs::abs;
+    use core::f32;
+
+    #[test]
+    fn sanity_check() {
+        let x = 3.0f32;
+        let y = 4.0f32;
+        let abs_difference = abs(hypot_approx(x, y) - sqrt_approx(25.0));
+        assert!(abs_difference <= f32::EPSILON);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,19 +78,12 @@
 //! [Variance]: https://docs.rs/micromath/latest/micromath/statistics/trait.Variance.html
 
 #![no_std]
-#![deny(
-    warnings,
-    missing_docs,
-    trivial_casts,
-    trivial_numeric_casts,
-    unused_import_braces,
-    unused_qualifications
-)]
-#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/NeoBirth/micromath/develop/img/micromath-sq.png",
     html_root_url = "https://docs.rs/micromath/0.4.1"
 )]
+#![forbid(unsafe_code)]
+#![warn(missing_docs, trivial_numeric_casts, unused_qualifications)]
 
 mod f32ext;
 #[cfg(feature = "quaternion")]


### PR DESCRIPTION
Implements `asin` and `acos` approximations in terms of `atan` and `sqrt_approx`/`invsqrt_approx`.

Implements `hypot` approximation in terms of `sqrt_approx`.

This completes the initial target feature set of this library.