### PR TITLE
Remove default cargo features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,13 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --target thumbv7em-none-eabihf --release
+          args: --release --target thumbv7em-none-eabihf
+
+      - name: Run cargo build --all-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features --release --target thumbv7em-none-eabihf
 
   test:
     name: Test Suite
@@ -76,6 +82,12 @@ jobs:
         with:
           command: test
           args: --release
+
+      - name: Run cargo test --all-features
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --all-features
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name        = "micromath"
 version     = "0.4.1" # Also update html_root_url in lib.rs when bumping this
 description = """
 Embedded-friendly math library featuring fast floating point approximations
-(with small code size) for common arithmetic operations, triganometry,
+(with small code size) for common arithmetic operations, trigonometry,
 2D/3D vector types, statistical analysis, and quaternions.
 """
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
@@ -12,14 +12,20 @@ repository  = "https://github.com/NeoBirth/micromath"
 readme      = "README.md"
 edition     = "2018"
 categories  = ["embedded", "science", "no-std"]
-keywords    = ["math", "quaternions", "statistics", "triganometry", "vector"]
+keywords    = ["math", "quaternions", "statistics", "trigonometry", "vector"]
+
+[badges]
+maintenance = { status = "passively-maintained" }
 
 [dependencies.generic-array]
 version = "0.13"
+optional = true
 default-features = false
 
 [features]
-default = ["quaternion", "statistics", "vector"]
 quaternion = []
 statistics = []
-vector = []
+vector = ["generic-array"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![Apache 2.0/MIT Licensed][license-image]][license-link]
 [![Gitter Chat][gitter-image]][gitter-link]
 
-Embedded Rust (i.e. `#![no_std]`-friendly) math library featuring fast, safe
-floating point approximations for common arithmetic operations, 2D and 3D
-vector types, statistical analysis, and quaternions.
+Embedded-friendly (i.e. `no_std`) Rust math library featuring fast, safe
+floating point approximations for common arithmetic operations, trigonometry,
+2D/3D vector types, statistical analysis, and quaternions.
 
 Optimizes for performance and small code size at the cost of precision.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,4 +98,5 @@ pub use crate::f32ext::F32Ext;
 pub use crate::quaternion::Quaternion;
 #[cfg(feature = "vector")]
 pub use crate::vector::{Vector, VectorExt};
+#[cfg(feature = "vector")]
 pub use generic_array;

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -22,7 +22,9 @@
 //! Quaternions are a number system that extends the complex numbers which can
 //! be used for efficiently computing spatial rotations.
 //!
-//! They are computed as the quotient of two directed lines in a
+//! The `quaternion` Cargo feature must be enabled to use this functionality.
+//!
+//! Quaternions are computed as the quotient of two directed lines in a
 //! three-dimensional space, or equivalently as the quotient of two vectors.
 //!
 //! For given real numbers `a`, `b`, `c`, and `d`, they take the form:

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -1,5 +1,7 @@
 //! Statistical analysis support.
 //!
+//! The `statistics` Cargo feature must be enabled to use this functionality.
+//!
 //! The following traits are available and impl'd for slices and iterators of
 //! `f32` (and can be impl'd for other types):
 //!

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,5 +1,7 @@
 //! Algebraic vector types generic over a number of axes and a component type.
 //!
+//! The `vector` Cargo feature must be enabled to use this functionality.
+//!
 //! All vectors types impl the [Vector] trait, and all vector components
 //! impl the [Component] trait. The [Vector] trait provides a number of
 //! features, including accessing components by `Index<usize>`, iterator


### PR DESCRIPTION
Disables all cargo features by default, requiring users opt-in.

Also makes `generic-array` an optional dependency.