### PR TITLE
v0.5.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.5.0] (2019-11-13)
+
+- Remove default cargo features ([#42])
+- Add `asin`, `acos`, and `hypot` ([#39])
+
 ## [0.4.1] (2019-10-08)
 
 - Implement `F32Ext::round` ([#37])
@@ -38,6 +43,9 @@
 
 - Initial release
 
+[0.5.0]: https://github.com/NeoBirth/micromath/pull/43
+[#42]: https://github.com/NeoBirth/micromath/pull/42
+[#39]: https://github.com/NeoBirth/micromath/pull/39
 [0.4.1]: https://github.com/NeoBirth/micromath/pull/38
 [#37]: https://github.com/NeoBirth/micromath/pull/37
 [0.4.0]: https://github.com/NeoBirth/micromath/pull/36

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name        = "micromath"
-version     = "0.4.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.5.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Embedded-friendly math library featuring fast floating point approximations
 (with small code size) for common arithmetic operations, trigonometry,
 2D/3D vector types, statistical analysis, and quaternions.
+Optimizes for performance and small code size at the cost of precision.
 """
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/NeoBirth/micromath/develop/img/micromath-sq.png",
-    html_root_url = "https://docs.rs/micromath/0.4.1"
+    html_root_url = "https://docs.rs/micromath/0.5.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
- Remove default cargo features (#42)
- Add `asin`, `acos`, and `hypot` (#39)