### PR TITLE
Deny warnings in CI; 2018 idiom fixups

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,12 +49,16 @@ jobs:
 
       - name: Run cargo build
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -D warnings
         with:
           command: build
           args: --release --target thumbv7em-none-eabihf
 
       - name: Run cargo build --all-features
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -D warnings
         with:
           command: build
           args: --all-features --release --target thumbv7em-none-eabihf
@@ -79,12 +83,16 @@ jobs:
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -D warnings
         with:
           command: test
           args: --release
 
       - name: Run cargo test --all-features
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: -D warnings
         with:
           command: test
           args: --release --all-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,13 @@
     html_root_url = "https://docs.rs/micromath/0.4.1"
 )]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, trivial_numeric_casts, unused_qualifications)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_qualifications
+)]
 
 mod f32ext;
 #[cfg(feature = "quaternion")]

--- a/src/statistics/trim.rs
+++ b/src/statistics/trim.rs
@@ -16,12 +16,12 @@ pub trait Trim {
 
     /// Trim this collection (cull outliers) at the default threshold of 2 standard
     /// deviations.
-    fn trim(&self) -> Iter<Self::Result> {
+    fn trim(&self) -> Iter<'_, Self::Result> {
         self.trim_at(DEFAULT_THRESHOLD)
     }
 
     /// Trim this collection (cull outliers) at the specified number of standard deviations.
-    fn trim_at(&self, threshold: f32) -> Iter<Self::Result>;
+    fn trim_at(&self, threshold: f32) -> Iter<'_, Self::Result>;
 }
 
 impl<N> Trim for &[N]
@@ -31,7 +31,7 @@ where
 {
     type Result = N;
 
-    fn trim_at(&self, threshold: f32) -> Iter<Self::Result> {
+    fn trim_at(&self, threshold: f32) -> Iter<'_, Self::Result> {
         Iter::new(self, threshold)
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -67,7 +67,7 @@ pub trait Vector: Copy + Debug + Default + Index<usize> + PartialEq + Sized + Se
     fn get(self, index: usize) -> Option<Self::Component>;
 
     /// Iterate over the components of a vector
-    fn iter(&self) -> Iter<Self> {
+    fn iter(&self) -> Iter<'_, Self> {
         Iter::new(self)
     }
 


### PR DESCRIPTION
Sets the `-D warnings` value in RUSTFLAGS so warnings are hard failures in CI.

Enables lints for `rust_2018_idioms`.