### PR TITLE
Bump `generic-array` dependency to v0.14; MSRV 1.36+

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.31.0
+          - 1.36.0
           - stable
     steps:
       - name: Checkout sources
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.31.0
+          - 1.36.0
           - stable
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords    = ["math", "quaternions", "statistics", "trigonometry", "vector"]
 maintenance = { status = "passively-maintained" }
 
 [dependencies.generic-array]
-version = "0.13"
+version = "0.14"
 optional = true
 default-features = false
 


### PR DESCRIPTION
As noted in the README.md, this is considered out-of-scope for SemVer.