### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,34 @@
-## 1.0.1 (2020-06-12)
+# Changelog
+All notable changes to this project will be documented in this file.
 
-- Add support for `powf` with negative bases ([#51])
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.1.0 (2020-09-30)
+### Added
+- `powi` support ([#53])
+
+### Changed
+- Bump `generic-array` dependency to v0.14; MSRV 1.36+ ([#54])
+
+[#54]: https://github.com/NeoBirth/micromath/pull/54
+[#53]: https://github.com/NeoBirth/micromath/pull/53
+
+## 1.0.1 (2020-06-12)
+### Added
+- Support for `powf` with negative bases ([#51])
 
 [#51]: https://github.com/NeoBirth/micromath/pull/51
 
 ## 1.0.0 (2019-12-02)
-
 - Initial 1.0 release! 🎉 (otherwise unchanged)
 
 ## 0.5.1 (2019-11-27)
-
 - Cargo.toml: Add mathematics category ([#45])
 
 [#45]: https://github.com/NeoBirth/micromath/pull/45
 
 ## 0.5.0 (2019-11-13)
-
 - Remove default cargo features ([#42])
 - Add `asin`, `acos`, and `hypot` ([#39])
 
@@ -23,25 +36,21 @@
 [#39]: https://github.com/NeoBirth/micromath/pull/39
 
 ## 0.4.1 (2019-10-08)
-
 - Implement `F32Ext::round` ([#37])
 
 [#37]: https://github.com/NeoBirth/micromath/pull/37
 
 ## 0.4.0 (2019-10-02)
-
 - Add `powf`, `exp`, `log10`, `log2`, `log`, `ln`, `trunc`, `fract`, `copysign` ([#35])
 
 [#35]: https://github.com/NeoBirth/micromath/pull/35
 
 ## 0.3.1 (2019-05-11)
-
 - Rust 1.31.0 support ([#33])
 
 [#33]: https://github.com/NeoBirth/micromath/pull/33
 
 ## 0.3.0 (2019-05-04)
-
 - statistics: Add Trim trait for statistical outlier culling iterators ([#29])
 - Quaternions ([#28])
 - f32ext: fast `inv()` approximation ([#27])
@@ -54,13 +63,11 @@
 [#25]: https://github.com/NeoBirth/micromath/pull/25
 
 ## 0.2.2 (2019-05-04)
-
 - Add `i32` and `u32` vectors ([#23])
 
 [#23]: https://github.com/NeoBirth/micromath/pull/23
 
 ## 0.2.1 (2019-05-03)
-
 - Add `html_logo_url` and square icon ([#20])
 - `README.md`: Update links to use 'develop' branch ([#19])
 
@@ -68,7 +75,6 @@
 [#19]: https://github.com/NeoBirth/micromath/pull/19
 
 ## 0.2.0 (2019-05-03)
-
 - `tan(x)` ([#17])
 - `invsqrt(x)` ([#16])
 - `cos(x)` and `sin(x)` ([#15])
@@ -82,5 +88,4 @@
 [#12]: https://github.com/NeoBirth/micromath/pull/12
 
 ## 0.1.0 (2019-05-03)
-
 - Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "micromath"
-version     = "1.0.1" # Also update html_root_url in lib.rs when bumping this
+version     = "1.1.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Embedded-friendly math library featuring fast floating point approximations
 (with small code size) for common arithmetic operations, trigonometry,

--- a/README.md
+++ b/README.md
@@ -16,14 +16,16 @@ Optimizes for performance and small code size at the cost of precision.
 
 [Documentation][docs-link]
 
-## Requirements
+## Minimum Supported Rust Version
 
-Requires Rust **1.31** or newer.
+Requires Rust **1.36** or newer.
+
+## Semver Policy
 
 In the future, we reserve the right to change the following:
 
 - Minimum Supported Rust Version
-- `generic-array` version (presently `^0.13`)
+- `generic-array` version (presently `^0.14`)
 
 i.e. these are explicitly out of scope for the SemVer guarantees this
 crate provides.
@@ -143,7 +145,7 @@ Apache 2.0 and MIT licenses.
 [build-link]: https://github.com/neobirth/micromath/actions
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
-[msrv-image]: https://img.shields.io/badge/rustc-1.31+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.36+-blue.svg
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
 [license-link]: https://github.com/NeoBirth/micromath/blob/develop/LICENSE-APACHE
 [gitter-image]: https://badges.gitter.im/NeoBirth/micromath.svg

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/NeoBirth/micromath/develop/img/micromath-sq.png",
-    html_root_url = "https://docs.rs/micromath/1.0.1"
+    html_root_url = "https://docs.rs/micromath/1.1.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
### Added
- `powi` support ([#53])

### Changed
- Bump `generic-array` dependency to v0.14; MSRV 1.36+ ([#54])

[#54]: https://github.com/NeoBirth/micromath/pull/54
[#53]: https://github.com/NeoBirth/micromath/pull/53