### PR TITLE
Make `quaternion` module private

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 //! processing, these approximations are often sufficient and the performance
 //! gains worth the lost precision.
 //!
-//! These approximations are provided by the [micromath::F32Ext] trait which is
-//! impl'd for `f32`, providing a drop-in `std`-compatible (sans lost precision) API.
+//! These approximations are provided by the [`F32Ext`] trait which is impl'd
+//! for `f32`, providing a drop-in `std`-compatible (sans lost precision) API.
 //!
 //! ```
 //! use micromath::F32Ext;
@@ -36,7 +36,7 @@
 //!
 //! ## Vector types
 //!
-//! See the [`vector` module] for more information on vector types.
+//! See the [`vector`] module for more information on vector types.
 //!
 //! The following vector types are available, all of which have `pub x` and
 //! `pub y` (and on 3D vectors, `pub z`) members:
@@ -53,29 +53,16 @@
 //!
 //! ## Statistical analysis
 //!
-//! See the [`statistics` module] for more information on statistical analysis
+//! See the [`statistics`] module for more information on statistical analysis
 //! traits and functionality.
 //!
 //! The following traits are available and impl'd for slices and iterators of
 //! `f32` (and can be impl'd for other types):
 //!
-//! - [Mean] - compute arithmetic mean with the `mean()` method
-//! - [StdDev] - compute standard deviation with the `stddev()` method
-//! - [Trim] - cull outliers from a sample slice with the `trim()` method.
-//! - [Variance] - compute variance with the `variance() method
-//!
-//! ## Quaternions
-//!
-//! See the [`quaternion` module] for more information.
-//!
-//! [micromath::F32Ext]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html
-//! [`vector` module]: https://docs.rs/micromath/latest/micromath/vector/index.html
-//! [`statistics` module]: https://docs.rs/micromath/latest/micromath/statistics/index.html
-//! [`quaternion` module]: https://docs.rs/micromath/latest/micromath/quaternion/index.html
-//! [Mean]: https://docs.rs/micromath/latest/micromath/statistics/trait.Mean.html
-//! [StdDev]: https://docs.rs/micromath/latest/micromath/statistics/trait.StdDev.html
-//! [Trim]: https://docs.rs/micromath/latest/micromath/statistics/trim/trait.Trim.html
-//! [Variance]: https://docs.rs/micromath/latest/micromath/statistics/trait.Variance.html
+//! - [`Mean`][`statistics::Mean`] - compute arithmetic mean with the `mean()` method.
+//! - [`StdDev`][`statistics::StdDev`] - compute standard deviation with the `stddev()` method.
+//! - [`Trim`][`statistics::Trim`] - cull outliers from a sample slice with the `trim()` method.
+//! - [`Variance`][`statistics::Variance`] - compute variance with the `variance()` method.
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -93,8 +80,7 @@
 )]
 
 #[cfg(feature = "quaternion")]
-#[cfg_attr(docsrs, doc(cfg(feature = "quaternion")))]
-pub mod quaternion;
+mod quaternion;
 
 #[cfg(feature = "statistics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "statistics")))]

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -1,52 +1,49 @@
-// Adapted from the madgwick crate: https://github.com/japaric/madgwick
-// Copyright (c) 2018 Jorge Aparicio
-//
-// Original sources dual licensed under your choice of the Apache 2.0
-// and/or MIT licenses, which matches this crate's licensing terms.
-//
-// See toplevel LICENSE-MIT for more information on the MIT license.
-// Apache 2.0 license follows:
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-//! Quaternions are a number system that extends the complex numbers which can
-//! be used for efficiently computing spatial rotations.
+//! Adapted from the `madgwick` crate: <https://github.com/japaric/madgwick>
+//! Copyright (c) 2018 Jorge Aparicio
 //!
-//! The `quaternion` Cargo feature must be enabled to use this functionality.
+//! Original sources dual licensed under your choice of the Apache 2.0
+//! and/or MIT licenses, which matches this crate's licensing terms.
 //!
-//! Quaternions are computed as the quotient of two directed lines in a
-//! three-dimensional space, or equivalently as the quotient of two vectors.
+//! See toplevel LICENSE-MIT for more information on the MIT license.
+//! Apache 2.0 license follows:
 //!
-//! For given real numbers `a`, `b`, `c`, and `d`, they take the form:
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at:
 //!
-//! `a + bi + cj + dk`
+//! <https://www.apache.org/licenses/LICENSE-2.0>
 //!
-//! where `i`, `j`, and `k` are the fundamental quaternion units:
-//!
-//! `i² = j² = k² = i*j*k = -1`
-//!
-//! Quaternion multiplication is noncommutative:
-//!
-//! | x | 1  | i  | j  | k  |
-//! |---|----|----|----|----|
-//! | 1 | 1  | i  | j  | k  |
-//! | i | i  | -1 | k  | -j |
-//! | j | j  | -k | -1 | i  |
-//! | k | k  | j  | -i | -1 |
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
 
 use core::ops::{AddAssign, Mul, MulAssign, SubAssign};
 
-/// Quaternion
+/// Quaternions are a number system that extends the complex numbers which can
+/// be used for efficiently computing spatial rotations.
+///
+/// They're computed as the quotient of two directed lines in a
+/// three-dimensional space, or equivalently as the quotient of two vectors.
+///
+/// For given real numbers `a`, `b`, `c`, and `d`, they take the form:
+///
+/// `a + bi + cj + dk`
+///
+/// where `i`, `j`, and `k` are the fundamental quaternion units:
+///
+/// `i² = j² = k² = i*j*k = -1`
+///
+/// Quaternion multiplication is non-commutative:
+///
+/// | x | 1  | i  | j  | k  |
+/// |---|----|----|----|----|
+/// | 1 | 1  | i  | j  | k  |
+/// | i | i  | -1 | k  | -j |
+/// | j | j  | -k | -1 | i  |
+/// | k | k  | j  | -i | -1 |
+#[cfg_attr(docsrs, doc(cfg(feature = "quaternion")))]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Quaternion(pub f32, pub f32, pub f32, pub f32);
 


### PR DESCRIPTION
The only type contained within is `Quaternion`, so it's simpler to just re-export that type from the toplevel than it is to have a separate module.