### PR TITLE
Add `F32` newtype

### DIFF
--- a/src/f32ext.rs
+++ b/src/f32ext.rs
@@ -1,34 +1,6 @@
-//! `f32` extension providing various arithmetic approximations and polyfills
-//! for `std` functionality.
+//! `f32` extension
 
-mod abs;
-mod acos;
-mod asin;
-mod atan;
-mod atan2;
-mod ceil;
-mod copysign;
-mod cos;
-mod div_euclid;
-mod exp;
-mod floor;
-mod fract;
-mod hypot;
-mod inv;
-mod invsqrt;
-mod ln;
-mod log;
-mod log10;
-mod log2;
-mod powf;
-mod powi;
-mod rem_euclid;
-mod round;
-mod sin;
-mod sqrt;
-mod tan;
-mod trunc;
-mod utils;
+use crate::float;
 
 /// `f32` extension providing various arithmetic approximations and polyfills
 /// for `std` functionality.
@@ -128,118 +100,118 @@ pub trait F32Ext: Sized {
 
 impl F32Ext for f32 {
     fn abs(self) -> f32 {
-        self::abs::abs(self)
+        float::abs::abs(self)
     }
 
     fn asin(self) -> f32 {
-        self::asin::asin_approx(self)
+        float::asin::asin_approx(self)
     }
 
     fn acos(self) -> f32 {
-        self::acos::acos_approx(self)
+        float::acos::acos_approx(self)
     }
 
     fn atan(self) -> f32 {
-        self::atan::atan_approx(self)
+        float::atan::atan_approx(self)
     }
 
     fn atan_norm(self) -> f32 {
-        self::atan::atan_norm_approx(self)
+        float::atan::atan_norm_approx(self)
     }
 
     fn atan2(self, other: f32) -> f32 {
-        self::atan2::atan2_approx(self, other)
+        float::atan2::atan2_approx(self, other)
     }
 
     fn atan2_norm(self, other: f32) -> f32 {
-        self::atan2::atan2_norm_approx(self, other)
+        float::atan2::atan2_norm_approx(self, other)
     }
 
     fn ceil(self) -> f32 {
-        self::ceil::ceil(self)
+        float::ceil::ceil(self)
     }
 
     fn cos(self) -> f32 {
-        self::cos::cos_approx(self)
+        float::cos::cos_approx(self)
     }
 
     fn div_euclid(self, other: f32) -> f32 {
-        self::div_euclid::div_euclid(self, other)
+        float::div_euclid::div_euclid(self, other)
     }
 
     fn floor(self) -> f32 {
-        self::floor::floor(self)
+        float::floor::floor(self)
     }
 
     fn hypot(self, other: f32) -> f32 {
-        self::hypot::hypot_approx(self, other)
+        float::hypot::hypot_approx(self, other)
     }
 
     fn inv(self) -> f32 {
-        self::inv::inv_approx(self)
+        float::inv::inv_approx(self)
     }
 
     fn invsqrt(self) -> f32 {
-        self::invsqrt::invsqrt_approx(self)
+        float::invsqrt::invsqrt_approx(self)
     }
 
     fn rem_euclid(self, other: f32) -> f32 {
-        self::rem_euclid::rem_euclid(self, other)
+        float::rem_euclid::rem_euclid(self, other)
     }
 
     fn sin(self) -> f32 {
-        self::sin::sin_approx(self)
+        float::sin::sin_approx(self)
     }
 
     fn sqrt(self) -> f32 {
-        self::sqrt::sqrt_approx(self)
+        float::sqrt::sqrt_approx(self)
     }
 
     fn tan(self) -> f32 {
-        self::tan::tan_approx(self)
+        float::tan::tan_approx(self)
     }
 
     fn trunc(self) -> f32 {
-        self::trunc::trunc_sign(self)
+        float::trunc::trunc_sign(self)
     }
 
     fn round(self) -> f32 {
-        self::round::round(self)
+        float::round::round(self)
     }
 
     fn fract(self) -> f32 {
-        self::fract::fract_sign(self)
+        float::fract::fract_sign(self)
     }
 
     fn copysign(self, sign: f32) -> f32 {
-        self::copysign::copysign(self, sign)
+        float::copysign::copysign(self, sign)
     }
 
     fn ln(self) -> f32 {
-        self::ln::ln_1to2_series_approximation(self)
+        float::ln::ln_1to2_series_approximation(self)
     }
 
     fn exp(self) -> f32 {
-        self::exp::exp_ln2_approximation(self, 4)
+        float::exp::exp_ln2_approximation(self, 4)
     }
 
     fn log(self, base: f32) -> f32 {
-        self::log::log_ln_approx(self, base)
+        float::log::log_ln_approx(self, base)
     }
 
     fn log2(self) -> f32 {
-        self::log2::log2_ln_approx(self)
+        float::log2::log2_ln_approx(self)
     }
 
     fn log10(self) -> f32 {
-        self::log10::log10_ln_approx(self)
+        float::log10::log10_ln_approx(self)
     }
 
     fn powf(self, n: f32) -> f32 {
-        self::powf::powf_exp_ln_approx(self, n)
+        float::powf::powf_exp_ln_approx(self, n)
     }
 
     fn powi(self, n: i32) -> f32 {
-        self::powi::powi_exp_by_squaring(self, n)
+        float::powi::powi_exp_by_squaring(self, n)
     }
 }

--- a/src/float.rs
+++ b/src/float.rs
@@ -1,0 +1,377 @@
+//! Floating point operations
+
+pub(crate) mod abs;
+pub(crate) mod acos;
+pub(crate) mod asin;
+pub(crate) mod atan;
+pub(crate) mod atan2;
+pub(crate) mod ceil;
+pub(crate) mod copysign;
+pub(crate) mod cos;
+pub(crate) mod div_euclid;
+pub(crate) mod exp;
+pub(crate) mod floor;
+pub(crate) mod fract;
+pub(crate) mod hypot;
+pub(crate) mod inv;
+pub(crate) mod invsqrt;
+pub(crate) mod ln;
+pub(crate) mod log;
+pub(crate) mod log10;
+pub(crate) mod log2;
+pub(crate) mod powf;
+pub(crate) mod powi;
+pub(crate) mod rem_euclid;
+pub(crate) mod round;
+pub(crate) mod sin;
+pub(crate) mod sqrt;
+pub(crate) mod tan;
+pub(crate) mod trunc;
+pub(crate) mod utils;
+
+use core::{
+    fmt::{self, Display, LowerExp, UpperExp},
+    iter::{Product, Sum},
+    num::ParseFloatError,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
+    str::FromStr,
+};
+
+/// 32-bit floating point wrapper which implements fast approximation-based
+/// operations.
+#[derive(Copy, Clone, Debug, Default, PartialEq, PartialOrd)]
+pub struct F32(pub f32);
+
+impl Add for F32 {
+    type Output = F32;
+
+    #[inline]
+    fn add(self, rhs: F32) -> F32 {
+        F32(self.0 + rhs.0)
+    }
+}
+
+impl Add<f32> for F32 {
+    type Output = F32;
+
+    #[inline]
+    fn add(self, rhs: f32) -> F32 {
+        F32(self.0 + rhs)
+    }
+}
+
+impl Add<F32> for f32 {
+    type Output = F32;
+
+    #[inline]
+    fn add(self, rhs: F32) -> F32 {
+        F32(self + rhs.0)
+    }
+}
+
+impl AddAssign for F32 {
+    #[inline]
+    fn add_assign(&mut self, rhs: F32) {
+        self.0 += rhs.0;
+    }
+}
+
+impl AddAssign<f32> for F32 {
+    #[inline]
+    fn add_assign(&mut self, rhs: f32) {
+        self.0 += rhs;
+    }
+}
+
+impl AddAssign<F32> for f32 {
+    #[inline]
+    fn add_assign(&mut self, rhs: F32) {
+        *self /= rhs.0;
+    }
+}
+
+impl Display for F32 {
+    #[inline]
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "{}", self.0)
+    }
+}
+
+impl Div for F32 {
+    type Output = F32;
+
+    #[inline]
+    fn div(self, rhs: F32) -> F32 {
+        F32(self.0 / rhs.0)
+    }
+}
+
+impl Div<f32> for F32 {
+    type Output = F32;
+
+    #[inline]
+    fn div(self, rhs: f32) -> F32 {
+        F32(self.0 / rhs)
+    }
+}
+
+impl Div<F32> for f32 {
+    type Output = F32;
+
+    #[inline]
+    fn div(self, rhs: F32) -> F32 {
+        F32(self / rhs.0)
+    }
+}
+
+impl DivAssign for F32 {
+    #[inline]
+    fn div_assign(&mut self, rhs: F32) {
+        self.0 /= rhs.0;
+    }
+}
+
+impl DivAssign<f32> for F32 {
+    #[inline]
+    fn div_assign(&mut self, rhs: f32) {
+        self.0 /= rhs;
+    }
+}
+
+impl DivAssign<F32> for f32 {
+    #[inline]
+    fn div_assign(&mut self, rhs: F32) {
+        *self /= rhs.0;
+    }
+}
+
+impl From<f32> for F32 {
+    #[inline]
+    fn from(n: f32) -> F32 {
+        F32(n)
+    }
+}
+
+impl From<F32> for f32 {
+    #[inline]
+    fn from(n: F32) -> f32 {
+        n.0
+    }
+}
+
+impl From<i8> for F32 {
+    #[inline]
+    fn from(n: i8) -> F32 {
+        F32(n.into())
+    }
+}
+
+impl From<i16> for F32 {
+    #[inline]
+    fn from(n: i16) -> F32 {
+        F32(n.into())
+    }
+}
+
+impl From<u8> for F32 {
+    #[inline]
+    fn from(n: u8) -> F32 {
+        F32(n.into())
+    }
+}
+
+impl From<u16> for F32 {
+    #[inline]
+    fn from(n: u16) -> F32 {
+        F32(n.into())
+    }
+}
+
+impl FromStr for F32 {
+    type Err = ParseFloatError;
+
+    #[inline]
+    fn from_str(src: &str) -> Result<F32, ParseFloatError> {
+        f32::from_str(src).map(F32)
+    }
+}
+
+impl LowerExp for F32 {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:e}", self.0)
+    }
+}
+
+impl Mul for F32 {
+    type Output = F32;
+
+    #[inline]
+    fn mul(self, rhs: F32) -> F32 {
+        F32(self.0 * rhs.0)
+    }
+}
+
+impl Mul<f32> for F32 {
+    type Output = F32;
+
+    #[inline]
+    fn mul(self, rhs: f32) -> F32 {
+        F32(self.0 * rhs)
+    }
+}
+
+impl Mul<F32> for f32 {
+    type Output = F32;
+
+    #[inline]
+    fn mul(self, rhs: F32) -> F32 {
+        F32(self * rhs.0)
+    }
+}
+
+impl MulAssign for F32 {
+    #[inline]
+    fn mul_assign(&mut self, rhs: F32) {
+        self.0 *= rhs.0;
+    }
+}
+
+impl MulAssign<f32> for F32 {
+    #[inline]
+    fn mul_assign(&mut self, rhs: f32) {
+        self.0 *= rhs;
+    }
+}
+
+impl MulAssign<F32> for f32 {
+    #[inline]
+    fn mul_assign(&mut self, rhs: F32) {
+        *self *= rhs.0;
+    }
+}
+
+impl Neg for F32 {
+    type Output = F32;
+
+    #[inline]
+    fn neg(self) -> F32 {
+        F32(-self.0)
+    }
+}
+
+impl Product for F32 {
+    #[inline]
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = F32>,
+    {
+        F32(f32::product(iter.map(f32::from)))
+    }
+}
+
+impl Rem for F32 {
+    type Output = F32;
+
+    #[inline]
+    fn rem(self, rhs: F32) -> F32 {
+        F32(self.0 % rhs.0)
+    }
+}
+
+impl Rem<f32> for F32 {
+    type Output = F32;
+
+    #[inline]
+    fn rem(self, rhs: f32) -> F32 {
+        F32(self.0 % rhs)
+    }
+}
+
+impl Rem<F32> for f32 {
+    type Output = F32;
+
+    #[inline]
+    fn rem(self, rhs: F32) -> F32 {
+        F32(self % rhs.0)
+    }
+}
+
+impl RemAssign for F32 {
+    #[inline]
+    fn rem_assign(&mut self, rhs: F32) {
+        self.0 %= rhs.0;
+    }
+}
+
+impl RemAssign<f32> for F32 {
+    #[inline]
+    fn rem_assign(&mut self, rhs: f32) {
+        self.0 %= rhs;
+    }
+}
+
+impl Sub for F32 {
+    type Output = F32;
+
+    #[inline]
+    fn sub(self, rhs: F32) -> F32 {
+        F32(self.0 - rhs.0)
+    }
+}
+
+impl Sub<f32> for F32 {
+    type Output = F32;
+
+    #[inline]
+    fn sub(self, rhs: f32) -> F32 {
+        F32(self.0 - rhs)
+    }
+}
+
+impl Sub<F32> for f32 {
+    type Output = F32;
+
+    #[inline]
+    fn sub(self, rhs: F32) -> F32 {
+        F32(self - rhs.0)
+    }
+}
+
+impl SubAssign for F32 {
+    #[inline]
+    fn sub_assign(&mut self, rhs: F32) {
+        self.0 -= rhs.0;
+    }
+}
+
+impl SubAssign<f32> for F32 {
+    #[inline]
+    fn sub_assign(&mut self, rhs: f32) {
+        self.0 -= rhs;
+    }
+}
+
+impl SubAssign<F32> for f32 {
+    #[inline]
+    fn sub_assign(&mut self, rhs: F32) {
+        *self -= rhs.0;
+    }
+}
+
+impl Sum for F32 {
+    #[inline]
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = F32>,
+    {
+        F32(f32::sum(iter.map(f32::from)))
+    }
+}
+
+impl UpperExp for F32 {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:E}", self.0)
+    }
+}

--- a/src/float/abs.rs
+++ b/src/float/abs.rs
@@ -2,7 +2,7 @@
 /// Method described at: <https://bits.stephan-brumme.com/absFloat.html>
 ///
 /// Constant-time, data-independent implementation.
-pub(super) fn abs(n: f32) -> f32 {
+pub(crate) fn abs(n: f32) -> f32 {
     f32::from_bits(n.to_bits() & 0x7FFF_FFFF)
 }
 

--- a/src/float/acos.rs
+++ b/src/float/acos.rs
@@ -6,14 +6,14 @@
 use super::{atan::atan_approx, sqrt::sqrt_approx};
 
 /// Computes `acos(x)` approximation in radians in the range `[0, pi]`
-pub(super) fn acos_approx(x: f32) -> f32 {
+pub(crate) fn acos_approx(x: f32) -> f32 {
     atan_approx(sqrt_approx(1.0 - x * x) / x)
 }
 
 #[cfg(test)]
 mod tests {
     use super::acos_approx;
-    use crate::f32ext::{abs::abs, cos::cos_approx};
+    use crate::float::{abs::abs, cos::cos_approx};
     use core::f32;
 
     const MAX_ERROR: f32 = 0.03;

--- a/src/float/asin.rs
+++ b/src/float/asin.rs
@@ -6,14 +6,14 @@
 use super::{atan::atan_approx, invsqrt::invsqrt_approx};
 
 /// Computes `asin(x)` approximation in radians in the range `[-pi/2, pi/2]`.
-pub(super) fn asin_approx(x: f32) -> f32 {
+pub(crate) fn asin_approx(x: f32) -> f32 {
     atan_approx(x * invsqrt_approx(1.0 - x * x))
 }
 
 #[cfg(test)]
 mod tests {
     use super::asin_approx;
-    use crate::f32ext::{abs::abs, sin::sin_approx};
+    use crate::float::{abs::abs, sin::sin_approx};
     use core::f32;
 
     #[test]

--- a/src/float/atan.rs
+++ b/src/float/atan.rs
@@ -7,13 +7,13 @@ use super::abs::abs;
 use core::f32;
 
 /// Computes `atan(x)` approximation in radians.
-pub(super) fn atan_approx(x: f32) -> f32 {
+pub(crate) fn atan_approx(x: f32) -> f32 {
     f32::consts::FRAC_PI_2 * atan_norm_approx(x)
 }
 
 /// Approximates `atan(x)` normalized to the `[−1,1]` range with a maximum
 /// error of `0.1620` degrees.
-pub(super) fn atan_norm_approx(x: f32) -> f32 {
+pub(crate) fn atan_norm_approx(x: f32) -> f32 {
     const SIGN_MASK: u32 = 0x8000_0000;
     const B: f32 = 0.596_227;
 

--- a/src/float/atan2.rs
+++ b/src/float/atan2.rs
@@ -7,14 +7,14 @@ use super::abs::abs;
 use core::f32::consts::PI;
 
 /// Computes an `atan2(y,x)` approximation in radians.
-pub(super) fn atan2_approx(y: f32, x: f32) -> f32 {
+pub(crate) fn atan2_approx(y: f32, x: f32) -> f32 {
     let n = atan2_norm_approx(y, x);
     PI / 2.0 * if n > 2.0 { n - 4.0 } else { n }
 }
 
 /// Approximates `atan2(y,x)` normalized to the `[0, 4)` range with a maximum
 /// error of `0.1620` degrees.
-pub(super) fn atan2_norm_approx(y: f32, x: f32) -> f32 {
+pub(crate) fn atan2_norm_approx(y: f32, x: f32) -> f32 {
     const SIGN_MASK: u32 = 0x8000_0000;
     const B: f32 = 0.596_227;
 

--- a/src/float/ceil.rs
+++ b/src/float/ceil.rs
@@ -1,7 +1,7 @@
 use super::floor::floor;
 
 /// Floating point ceiling approximation for a single-precision float
-pub(super) fn ceil(x: f32) -> f32 {
+pub(crate) fn ceil(x: f32) -> f32 {
     -floor(-x)
 }
 

--- a/src/float/copysign.rs
+++ b/src/float/copysign.rs
@@ -3,7 +3,7 @@ use super::utils;
 use core::f32;
 use core::u32;
 
-pub(super) fn copysign(destination: f32, source: f32) -> f32 {
+pub(crate) fn copysign(destination: f32, source: f32) -> f32 {
     let source_bits: u32 = source.to_bits();
     let source_sign: u32 = source_bits & utils::SIGN_MASK;
     let signless_destination_bits: u32 = destination.to_bits() & !utils::SIGN_MASK;

--- a/src/float/cos.rs
+++ b/src/float/cos.rs
@@ -6,7 +6,7 @@ use super::floor::floor;
 use core::f32;
 
 /// Approximates `cos(x)` in radians with a maximum error of `0.002`
-pub(super) fn cos_approx(mut x: f32) -> f32 {
+pub(crate) fn cos_approx(mut x: f32) -> f32 {
     x *= f32::consts::FRAC_1_PI / 2.0;
     x -= 0.25 + floor(x + 0.25);
     x *= 16.0 * (abs(x) - 0.5);
@@ -15,7 +15,7 @@ pub(super) fn cos_approx(mut x: f32) -> f32 {
 }
 
 #[cfg(test)]
-pub(super) mod tests {
+pub(crate) mod tests {
     use super::{abs, cos_approx};
 
     /// Maximum error in radians

--- a/src/float/div_euclid.rs
+++ b/src/float/div_euclid.rs
@@ -1,7 +1,7 @@
 /// Euclidean division for f32
 use super::trunc;
 
-pub(super) fn div_euclid(x: f32, y: f32) -> f32 {
+pub(crate) fn div_euclid(x: f32, y: f32) -> f32 {
     let q = trunc::trunc_sign(x / y);
     if x % y < 0.0 {
         return if y > 0.0 { q - 1.0 } else { q + 1.0 };

--- a/src/float/exp.rs
+++ b/src/float/exp.rs
@@ -3,7 +3,7 @@ use super::abs;
 use super::fract;
 use super::trunc;
 use super::utils;
-use crate::f32ext::utils::FloatComponents;
+use crate::float::utils::FloatComponents;
 use core::f32;
 use core::i32;
 use core::u32;
@@ -18,7 +18,7 @@ pub(crate) fn exp_smallx(x: f32, iter: u32) -> f32 {
     total
 }
 
-pub(super) fn exp_ln2_approximation(x: f32, partial_iter: u32) -> f32 {
+pub(crate) fn exp_ln2_approximation(x: f32, partial_iter: u32) -> f32 {
     // idea from# https://stackoverflow.com/a/6985769/2036035
     if x == 0.0_f32 {
         return 1.0;

--- a/src/float/floor.rs
+++ b/src/float/floor.rs
@@ -1,5 +1,5 @@
 /// Floating point floor approximation for a single-precision float.
-pub(super) fn floor(x: f32) -> f32 {
+pub(crate) fn floor(x: f32) -> f32 {
     let mut x_trunc = (x as i32) as f32;
 
     if x < x_trunc {

--- a/src/float/fract.rs
+++ b/src/float/fract.rs
@@ -6,7 +6,7 @@ use super::utils::FloatComponents;
 use core::f32;
 use core::u32;
 
-pub(super) fn fract_sign(x: f32) -> f32 {
+pub(crate) fn fract_sign(x: f32) -> f32 {
     let x_bits: u32 = x.to_bits();
     let exponent: i32 = x.extract_exponent_value();
     // we know it is *only* fraction

--- a/src/float/hypot.rs
+++ b/src/float/hypot.rs
@@ -4,14 +4,14 @@ use super::sqrt::sqrt_approx;
 
 /// Calculate the length of the hypotenuse of a right-angle triangle given
 /// legs of length `x` and `y`.
-pub(super) fn hypot_approx(x: f32, y: f32) -> f32 {
+pub(crate) fn hypot_approx(x: f32, y: f32) -> f32 {
     sqrt_approx(x * x + y * y)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{hypot_approx, sqrt_approx};
-    use crate::f32ext::abs::abs;
+    use crate::float::abs::abs;
     use core::f32;
 
     #[test]

--- a/src/float/inv.rs
+++ b/src/float/inv.rs
@@ -1,11 +1,11 @@
 /// Fast approximation of `1/x`.
 /// Method described at: <https://bits.stephan-brumme.com/inverse.html>
-pub(super) fn inv_approx(x: f32) -> f32 {
+pub(crate) fn inv_approx(x: f32) -> f32 {
     f32::from_bits(0x7f00_0000 - x.to_bits())
 }
 
 #[cfg(test)]
-pub(super) mod tests {
+pub(crate) mod tests {
     use super::inv_approx;
 
     /// Deviation from the actual value (8%)

--- a/src/float/invsqrt.rs
+++ b/src/float/invsqrt.rs
@@ -1,13 +1,13 @@
 /// Inverse square root approximation function for a single-precision float.
 /// Method described at: <https://bits.stephan-brumme.com/invSquareRoot.html>
-pub(super) fn invsqrt_approx(x: f32) -> f32 {
+pub(crate) fn invsqrt_approx(x: f32) -> f32 {
     f32::from_bits(0x5f37_5a86 - (x.to_bits() >> 1))
 }
 
 #[cfg(test)]
 mod tests {
     use super::invsqrt_approx;
-    use crate::f32ext::sqrt::tests::TEST_VECTORS;
+    use crate::float::sqrt::tests::TEST_VECTORS;
 
     /// Deviation from the actual value (5%)
     const MAX_ERROR: f32 = 0.05;

--- a/src/float/ln.rs
+++ b/src/float/ln.rs
@@ -8,7 +8,7 @@ use core::u32;
 //excessive precision ignored because it hides the origin of the numbers used for the ln(1.0->2.0)
 // polynomial
 #[allow(clippy::excessive_precision)]
-pub(super) fn ln_1to2_series_approximation(x: f32) -> f32 {
+pub(crate) fn ln_1to2_series_approximation(x: f32) -> f32 {
     // idea from https://stackoverflow.com/a/44232045/
     // modified to not be restricted to int range and only values of x above 1.0.
     // and got rid of most of the slow conversions,

--- a/src/float/log.rs
+++ b/src/float/log.rs
@@ -1,7 +1,7 @@
 /// log_b(a) approximation for f32
 use super::ln;
 
-pub(super) fn log_ln_approx(x: f32, base: f32) -> f32 {
+pub(crate) fn log_ln_approx(x: f32, base: f32) -> f32 {
     //using change of base log_base(x) = ln(x)/ln(base)
     let fract_base_ln = 1.0 / ln::ln_1to2_series_approximation(base);
     let value_ln = ln::ln_1to2_series_approximation(x);

--- a/src/float/log10.rs
+++ b/src/float/log10.rs
@@ -1,7 +1,7 @@
 /// log base 2 approximation for f32
 use super::ln;
 use core::f32;
-pub(super) fn log10_ln_approx(x: f32) -> f32 {
+pub(crate) fn log10_ln_approx(x: f32) -> f32 {
     //using change of base log10(x) = ln(x)/ln(10)
     let ln10_recip = f32::consts::LOG10_E;
     let fract_base_ln = ln10_recip;

--- a/src/float/log2.rs
+++ b/src/float/log2.rs
@@ -1,7 +1,7 @@
 /// log base 2 approximation for f32
 use super::ln;
 use core::f32;
-pub(super) fn log2_ln_approx(x: f32) -> f32 {
+pub(crate) fn log2_ln_approx(x: f32) -> f32 {
     //using change of base log2(x) = ln(x)/ln(2)
     let ln2_recip: f32 = f32::consts::LOG2_E;
     let fract_base_ln = ln2_recip;

--- a/src/float/powf.rs
+++ b/src/float/powf.rs
@@ -1,10 +1,10 @@
 /// x^n with fractional n approximation for f32
 use super::exp;
 use super::ln;
-use crate::f32ext::utils::FloatComponents;
+use crate::float::utils::FloatComponents;
 use core::f32;
 
-pub(super) fn powf_exp_ln_approx(x: f32, n: f32) -> f32 {
+pub(crate) fn powf_exp_ln_approx(x: f32, n: f32) -> f32 {
     // using x^n = exp(ln(x^n)) = exp(n*ln(x))
     if x < 0.0 {
         if !n.is_integer() {

--- a/src/float/powi.rs
+++ b/src/float/powi.rs
@@ -1,10 +1,10 @@
 use super::abs;
 use super::utils;
 /// x^n where n is an integer
-use crate::f32ext::utils::FloatComponents;
+use crate::float::utils::FloatComponents;
 use core::f32;
 
-pub(super) fn powi_exp_by_squaring(x: f32, n: i32) -> f32 {
+pub(crate) fn powi_exp_by_squaring(x: f32, n: i32) -> f32 {
     // source: https://stackoverflow.com/a/101613
     // note not optimal for all powers, is NP complete
     // https://en.wikipedia.org/wiki/Addition-chain_exponentiation

--- a/src/float/rem_euclid.rs
+++ b/src/float/rem_euclid.rs
@@ -1,7 +1,7 @@
 /// Euclidean reminder for f32
 use super::abs;
 
-pub(super) fn rem_euclid(x: f32, y: f32) -> f32 {
+pub(crate) fn rem_euclid(x: f32, y: f32) -> f32 {
     let r = x % y;
     if r < 0.0 {
         r + abs::abs(y)

--- a/src/float/round.rs
+++ b/src/float/round.rs
@@ -1,6 +1,6 @@
 use super::copysign::copysign;
 
-pub(super) fn round(x: f32) -> f32 {
+pub(crate) fn round(x: f32) -> f32 {
     ((x + copysign(0.5, x)) as i32) as f32
 }
 

--- a/src/float/sin.rs
+++ b/src/float/sin.rs
@@ -4,14 +4,14 @@ use super::cos::cos_approx;
 use core::f32::consts::PI;
 
 /// Approximates `sin(x)` in radians with a maximum error of `0.002`
-pub(super) fn sin_approx(x: f32) -> f32 {
+pub(crate) fn sin_approx(x: f32) -> f32 {
     cos_approx(x - PI / 2.0)
 }
 
 #[cfg(test)]
 mod tests {
     use super::sin_approx;
-    use crate::f32ext::{abs::abs, cos::tests::MAX_ERROR};
+    use crate::float::{abs::abs, cos::tests::MAX_ERROR};
 
     /// Sine test vectors - `(input, output)`
     const TEST_VECTORS: &[(f32, f32)] = &[

--- a/src/float/sqrt.rs
+++ b/src/float/sqrt.rs
@@ -1,11 +1,11 @@
 /// Square root approximation function for a single-precision float.
 /// Method described at: <https://bits.stephan-brumme.com/squareRoot.html>
-pub(super) fn sqrt_approx(x: f32) -> f32 {
+pub(crate) fn sqrt_approx(x: f32) -> f32 {
     f32::from_bits((x.to_bits() + 0x3f80_0000) >> 1)
 }
 
 #[cfg(test)]
-pub(super) mod tests {
+pub(crate) mod tests {
     use super::sqrt_approx;
 
     /// Deviation from the actual value (5%)

--- a/src/float/tan.rs
+++ b/src/float/tan.rs
@@ -3,14 +3,14 @@
 use super::{cos::cos_approx, sin::sin_approx};
 
 /// Computes `tan(x)` approximation in radians.
-pub(super) fn tan_approx(x: f32) -> f32 {
+pub(crate) fn tan_approx(x: f32) -> f32 {
     sin_approx(x) / cos_approx(x)
 }
 
 #[cfg(test)]
 mod tests {
     use super::tan_approx;
-    use crate::f32ext::abs::abs;
+    use crate::float::abs::abs;
 
     /// Maximum error in radians
     // TODO(tarcieri): this is kinda bad, find a better approximation?

--- a/src/float/trunc.rs
+++ b/src/float/trunc.rs
@@ -5,7 +5,7 @@ use super::utils::FloatComponents;
 use core::f32;
 use core::u32;
 
-pub(super) fn trunc_sign(x: f32) -> f32 {
+pub(crate) fn trunc_sign(x: f32) -> f32 {
     let x_bits: u32 = x.to_bits();
     let exponent: i32 = x.extract_exponent_value();
     //exponent is negative, there is no whole number, just return zero

--- a/src/float/utils.rs
+++ b/src/float/utils.rs
@@ -7,7 +7,7 @@ pub const EXPONENT_BIAS: u32 = 127;
 // MANTISSA_DIGITS is availible in core::f32, but the actual bits taken up are 24 - 1
 pub const MANTISSA_BITS: u32 = 23;
 
-pub(super) trait FloatComponents<IntType = i32, UIntType = u32> {
+pub(crate) trait FloatComponents<IntType = i32, UIntType = u32> {
     fn extract_sign_bit(self) -> UIntType;
     fn extract_exponent_bits(self) -> UIntType;
     fn extract_mantissa_bits(self) -> UIntType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,9 +79,6 @@
     unused_qualifications
 )]
 
-#[cfg(feature = "quaternion")]
-mod quaternion;
-
 #[cfg(feature = "statistics")]
 #[cfg_attr(docsrs, doc(cfg(feature = "statistics")))]
 pub mod statistics;
@@ -91,8 +88,11 @@ pub mod statistics;
 pub mod vector;
 
 mod f32ext;
+mod float;
+#[cfg(feature = "quaternion")]
+mod quaternion;
 
-pub use crate::f32ext::F32Ext;
+pub use crate::{f32ext::F32Ext, float::F32};
 
 #[cfg(feature = "quaternion")]
 pub use crate::quaternion::Quaternion;

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -118,7 +118,7 @@ impl Mul<Quaternion> for f32 {
 #[cfg(test)]
 mod tests {
     use super::Quaternion;
-    use crate::f32ext::F32Ext;
+    use crate::F32Ext;
 
     const MAX_ERROR: f32 = 0.05;
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -11,7 +11,7 @@ use core::{
 };
 
 #[allow(unused_imports)]
-use crate::f32ext::F32Ext;
+use crate::F32Ext;
 
 /// Components of numeric vectors.
 ///


### PR DESCRIPTION
Adds a newtype for `f32` which can be used as an alternative to `F32Ext`.

The longer-term goal is to implement all of the current floating point operations provided by this library on the newtype, and use the newtype to impl `F32Ext`.

This will also allow us to implement traits from the `num-traits` crate (#57).