### PR TITLE
Add initial `num-traits` support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,7 @@ jobs:
           override: true
           profile: minimal
       - run: cargo build --target ${{ matrix.target }} --release --no-default-features
+      - run: cargo build --target ${{ matrix.target }} --release --no-default-features --features num-traits
 
   test:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ edition     = "2018"
 categories  = ["embedded", "mathematics", "science", "no-std"]
 keywords    = ["math", "quaternions", "statistics", "trigonometry", "vector"]
 
+[dependencies]
+num-traits = { version = "0.2", optional = true, default-features = false }
+
 [features]
 quaternion = []
 statistics = []

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ Optimizes for performance and small code size at the cost of precision.
 
 Requires Rust **1.47** or newer.
 
-In the future, we reserve the right to change MSRV (i.e. MSRV is out-of-scope
-for this crate's SemVer guarantees), however when we do it will be accompanied by
-a minor version bump.
+## SemVer Policy
+
+We reserve the right to change the following in future releases with a minor
+version bump *only*:
+
+- MSRV
+- `num-traits` version (optional dependency)
 
 ## Features
 

--- a/src/float.rs
+++ b/src/float.rs
@@ -37,6 +37,9 @@ use core::{
     str::FromStr,
 };
 
+#[cfg(feature = "num-traits")]
+use num_traits::{Num, One, Zero};
+
 /// Sign mask.
 pub(crate) const SIGN_MASK: u32 = 0b1000_0000_0000_0000_0000_0000_0000_0000;
 
@@ -582,5 +585,39 @@ impl UpperExp for F32 {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:E}", self.0)
+    }
+}
+
+#[cfg(feature = "num-traits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "num-traits")))]
+impl Zero for F32 {
+    fn zero() -> Self {
+        Self::ZERO
+    }
+
+    fn is_zero(&self) -> bool {
+        Self::ZERO == *self
+    }
+}
+
+#[cfg(feature = "num-traits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "num-traits")))]
+impl One for F32 {
+    fn one() -> Self {
+        Self::ONE
+    }
+
+    fn is_one(&self) -> bool {
+        Self::ONE == *self
+    }
+}
+
+#[cfg(feature = "num-traits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "num-traits")))]
+impl Num for F32 {
+    type FromStrRadixErr = num_traits::ParseFloatError;
+
+    fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+        f32::from_str_radix(str, radix).map(Self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,3 +98,7 @@ pub use crate::{f32ext::F32Ext, float::F32};
 
 #[cfg(feature = "quaternion")]
 pub use crate::quaternion::Quaternion;
+
+#[cfg(feature = "num-traits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "num-traits")))]
+pub use num_traits;


### PR DESCRIPTION
Adds a conditional impl of the `Num` trait for `F32`, gated on the `num-traits` feature.

Closes #57.