### PR TITLE
quaternion: add more ops (e.g. dot, inv)

### DIFF
--- a/src/float.rs
+++ b/src/float.rs
@@ -38,7 +38,7 @@ use core::{
 };
 
 #[cfg(feature = "num-traits")]
-use num_traits::{Num, One, Zero};
+use num_traits::{Inv, Num, One, Zero};
 
 /// Sign mask.
 pub(crate) const SIGN_MASK: u32 = 0b1000_0000_0000_0000_0000_0000_0000_0000;
@@ -619,5 +619,27 @@ impl Num for F32 {
 
     fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
         f32::from_str_radix(str, radix).map(Self)
+    }
+}
+
+#[cfg(feature = "num-traits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "num-traits")))]
+impl Inv for F32 {
+    type Output = Self;
+
+    fn inv(self) -> Self {
+        self.inv()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)] // remove when we have more tests
+    use super::F32;
+
+    #[cfg(feature = "num-traits")]
+    #[test]
+    fn inv_trait() {
+        assert_eq!(num_traits::Inv::inv(F32(2.0)), F32(0.5));
     }
 }

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -19,7 +19,7 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
-use core::ops::{AddAssign, Mul, MulAssign, SubAssign};
+use core::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 
 /// Quaternions are a number system that extends the complex numbers which can
 /// be used for efficiently computing spatial rotations.
@@ -48,19 +48,43 @@ use core::ops::{AddAssign, Mul, MulAssign, SubAssign};
 pub struct Quaternion(pub f32, pub f32, pub f32, pub f32);
 
 impl Quaternion {
-    /// Returns the conjugate of this quaternion
+    /// Returns the conjugate of this quaternion.
     pub fn conj(self) -> Self {
         Quaternion(self.0, -self.1, -self.2, -self.3)
     }
 
-    /// Returns the norm of this quaternion
+    /// Returns the dot product of this quaternion.
+    pub fn dot(self, rhs: Self) -> f32 {
+        self.0 * rhs.0 + self.1 * rhs.1 + self.2 * rhs.2 + self.3 * rhs.3
+    }
+
+    /// Compute the inverse of this quaternion.
+    pub fn inv(self) -> Self {
+        let norm = self.norm();
+        self.conj() * (1.0 / (norm * norm))
+    }
+
+    /// Returns the norm of this quaternion.
     pub fn norm(self) -> f32 {
         self.0 * self.0 + self.1 * self.1 + self.2 * self.2 + self.3 * self.3
     }
 }
 
-impl AddAssign<Quaternion> for Quaternion {
-    fn add_assign(&mut self, rhs: Quaternion) {
+impl Add for Quaternion {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        Self(
+            self.0 + rhs.0,
+            self.1 + rhs.1,
+            self.2 + rhs.2,
+            self.3 + rhs.3,
+        )
+    }
+}
+
+impl AddAssign for Quaternion {
+    fn add_assign(&mut self, rhs: Self) {
         self.0 += rhs.0;
         self.1 += rhs.1;
         self.2 += rhs.2;
@@ -68,17 +92,21 @@ impl AddAssign<Quaternion> for Quaternion {
     }
 }
 
-impl MulAssign<f32> for Quaternion {
-    fn mul_assign(&mut self, k: f32) {
-        self.0 *= k;
-        self.1 *= k;
-        self.2 *= k;
-        self.3 *= k;
+impl Sub for Quaternion {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        Self(
+            self.0 - rhs.0,
+            self.1 - rhs.1,
+            self.2 - rhs.2,
+            self.3 - rhs.3,
+        )
     }
 }
 
-impl SubAssign<Quaternion> for Quaternion {
-    fn sub_assign(&mut self, rhs: Quaternion) {
+impl SubAssign for Quaternion {
+    fn sub_assign(&mut self, rhs: Self) {
         self.0 -= rhs.0;
         self.1 -= rhs.1;
         self.2 -= rhs.2;
@@ -86,11 +114,11 @@ impl SubAssign<Quaternion> for Quaternion {
     }
 }
 
-impl Mul<Quaternion> for Quaternion {
+impl Mul for Quaternion {
     type Output = Self;
 
     fn mul(self, other: Self) -> Self {
-        Quaternion(
+        Self(
             self.0 * other.0 - self.1 * other.1 - self.2 * other.2 - self.3 * other.3,
             self.0 * other.1 + self.1 * other.0 + self.2 * other.3 - self.3 * other.2,
             self.0 * other.2 - self.1 * other.3 + self.2 * other.0 + self.3 * other.1,
@@ -112,6 +140,12 @@ impl Mul<Quaternion> for f32 {
 
     fn mul(self, q: Quaternion) -> Quaternion {
         q * self
+    }
+}
+
+impl MulAssign<f32> for Quaternion {
+    fn mul_assign(&mut self, k: f32) {
+        *self = *self * k;
     }
 }
 


### PR DESCRIPTION
Adds dot product and inverse support to `Quaternion`.

Also adds additional impls of various `core` ops (e.g. `Add`, `Sub`)

Closes #56 