### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.0.0-pre (2021-04-24)
+## 2.0.0 (2021-05-15)
 ### Added
 - `Vector` subtraction support ([#71])
 - `F32` newtype ([#72], [#75])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "micromath"
-version     = "2.0.0-pre" # Also update html_root_url in lib.rs when bumping this
+version     = "2.0.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Embedded-friendly math library featuring fast floating point approximations
 (with small code size) for common arithmetic operations, trigonometry,
@@ -21,7 +21,7 @@ num-traits = { version = "0.2", optional = true, default-features = false }
 [features]
 quaternion = []
 statistics = []
-vector = []
+vector     = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Apache 2.0 and MIT licenses.
 
 [//]: # (badges)
 
-[crate-img]: https://img.shields.io/crates/v/micromath.svg
+[crate-img]: https://img.shields.io/crates/v/micromath.svg?logo=rust
 [crate-link]: https://crates.io/crates/micromath
 [docs-img]: https://docs.rs/micromath/badge.svg
 [docs-link]: https://docs.rs/micromath/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tarcieri/micromath/main/img/micromath-sq.png",
-    html_root_url = "https://docs.rs/micromath/2.0.0-pre"
+    html_root_url = "https://docs.rs/micromath/2.0.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(


### PR DESCRIPTION
### Added
- `Vector` subtraction support ([#71])
- `F32` newtype ([#72], [#75])
- `num-traits` support ([#80])
- `Quaternion::dot` and `::inv` ([#81])
- `Vector3d` ops for `Quaternion` ([#82])
- `Quaternion::magnitude`, `::scale`, `::to_array`, and `::IDENTITY` ([#83])
- `Quaternion::axis_angle` ([#84])
- `Quaternion::new` ([#85])

### Changed
- Refactor `Vector` types ([#69])
- MSRV 1.47+ ([#75])
- Make `Quaternion` opaque and module private ([#70], [#85])

### Fixed
- `acos()` behavior for zero/negative ([#79])

[#69]: https://github.com/tarcieri/micromath/pull/69
[#70]: https://github.com/tarcieri/micromath/pull/70
[#71]: https://github.com/tarcieri/micromath/pull/71
[#72]: https://github.com/tarcieri/micromath/pull/72
[#75]: https://github.com/tarcieri/micromath/pull/75
[#79]: https://github.com/tarcieri/micromath/pull/79
[#80]: https://github.com/tarcieri/micromath/pull/80
[#81]: https://github.com/tarcieri/micromath/pull/81
[#82]: https://github.com/tarcieri/micromath/pull/82
[#83]: https://github.com/tarcieri/micromath/pull/83
[#84]: https://github.com/tarcieri/micromath/pull/84
[#85]: https://github.com/tarcieri/micromath/pull/85