### PR TITLE
Quaternion to Euler Angles conversion

### DIFF
--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -133,6 +133,17 @@ impl Quaternion {
         Self(self.0 * k, self.1 * k, self.2 * k, self.3 * k)
     }
 
+    /// Get the (roll, pitch, yaw) Euler angles, assumes the quaternion is normalized.
+    pub fn to_euler(&self) -> (f32, f32, f32) {
+        let r = F32(2. * (self.0 * self.1 + self.2 * self.3))
+            .atan2(F32(1. - 2. * (self.1 * self.1 + self.2 * self.2)));
+        let p = F32(2. * (self.0 * self.2 - self.1 * self.3)).asin();
+        let y = F32(2. * (self.0 * self.3 + self.1 * self.2))
+            .atan2(F32(1. - 2. * (self.2 * self.2 + self.3 * self.3)));
+
+        (r.0, p.0, y.0)
+    }
+
     /// Convert this quaternion into an array.
     pub fn to_array(&self) -> [f32; 4] {
         [self.0, self.1, self.2, self.3]


### PR DESCRIPTION
Hi,

I added the bog-standard Quaternion -> Euler angles conversion (https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles)
Not sure how "unity" constraints are viewed in this library, so I went with the simplest approach.