### PR TITLE
Add defmt support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request: {}
+  pull_request: { }
   push:
     branches: main
 
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.47.0 # MSRV
+          - 1.62.0 # MSRV
           - stable
         target:
           # - armv7a-none-eabi
@@ -50,7 +50,7 @@ jobs:
         include:
           # 32-bit Linux
           - target: i686-unknown-linux-gnu
-            rust: 1.47.0 # MSRV
+            rust: 1.62.0 # MSRV
             deps: sudo apt update && sudo apt install gcc-multilib
           - target: i686-unknown-linux-gnu
             rust: stable
@@ -58,7 +58,7 @@ jobs:
 
           # 64-bit Linux
           - target: x86_64-unknown-linux-gnu
-            rust: 1.47.0 # MSRV
+            rust: 1.62.0 # MSRV
           - target: x86_64-unknown-linux-gnu
             rust: stable
 
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.47.0 # MSRV
+          toolchain: 1.62.0 # MSRV
           components: clippy
           override: true
           profile: minimal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,9 +9,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "defmt"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a99dd22262668b887121d4672af5a64b238f026099f1a2a1b322066c9ecfe9e0"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9f309eff1f79b3ebdf252954d90ae440599c26c2c553fe87a2d17195f2dcb"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4a5fefe330e8d7f31b16a318f9ce81000d8e35e69b93eae154d16d2278f70f"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "micromath"
 version = "2.1.0"
 dependencies = [
+ "defmt",
  "num-traits",
 ]
 
@@ -23,3 +62,98 @@ checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,14 @@ categories  = ["embedded", "mathematics", "science", "no-std"]
 keywords    = ["math", "quaternions", "statistics", "trigonometry", "vector"]
 
 [dependencies]
+defmt = { version = "0.3.8", optional = true, default-features = false }
 num-traits = { version = "0.2", optional = true, default-features = false }
 
 [features]
 quaternion = []
 statistics = []
 vector     = []
+defmt      = ["dep:defmt"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Optimizes for performance and small code size at the cost of precision.
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.47** or newer.
+Requires Rust **1.62** or newer.
 
 ## SemVer Policy
 
@@ -30,59 +30,59 @@ version bump *only*:
 ## Features
 
 - [`f32` extension]:
-  - Fast approximations:
-    - [asin]
-    - [acos]
-    - [atan]
-    - [atan2]
-    - [cos]
-    - [hypot]
-    - [inv]
-    - [invsqrt]
-    - [ln]
-    - [log]
-    - [log2]
-    - [log10]
-    - [powf]
-    - [exp]
-    - [sin]
-    - [sqrt]
-    - [tan]
-  - `std` polyfills:
-    - [abs]
-    - [ceil]
-    - [floor]
-    - [round]
-    - [trunc]
-    - [fract]
-    - [copysign]
-    - [signum]
-    - [sin_cos]
-    - [mul_add]
-    - [recip]
+    - Fast approximations:
+        - [asin]
+        - [acos]
+        - [atan]
+        - [atan2]
+        - [cos]
+        - [hypot]
+        - [inv]
+        - [invsqrt]
+        - [ln]
+        - [log]
+        - [log2]
+        - [log10]
+        - [powf]
+        - [exp]
+        - [sin]
+        - [sqrt]
+        - [tan]
+    - `std` polyfills:
+        - [abs]
+        - [ceil]
+        - [floor]
+        - [round]
+        - [trunc]
+        - [fract]
+        - [copysign]
+        - [signum]
+        - [sin_cos]
+        - [mul_add]
+        - [recip]
 
 - [Algebraic vector types]:
-  - 2D:
-    - [I8x2]
-    - [I16x2]
-    - [I32x2]
-    - [U8x2]
-    - [U16x2]
-    - [U32x2]
-    - [F32x2]
-  - 3D:
-    - [I8x3]
-    - [I16x3]
-    - [I32x3]
-    - [U8x3]
-    - [U16x3]
-    - [U32x3]
-    - [F32x3]
+    - 2D:
+        - [I8x2]
+        - [I16x2]
+        - [I32x2]
+        - [U8x2]
+        - [U16x2]
+        - [U32x2]
+        - [F32x2]
+    - 3D:
+        - [I8x3]
+        - [I16x3]
+        - [I32x3]
+        - [U8x3]
+        - [U16x3]
+        - [U32x3]
+        - [F32x3]
 - [Statistical analysis]:
-  - [mean]
-  - [stddev]
-  - [trim]
-  - [variance]
+    - [mean]
+    - [stddev]
+    - [trim]
+    - [variance]
 - [Quaternions]
 
 ## Code of Conduct
@@ -102,77 +102,142 @@ Dual licensed under your choice of either of:
 
 Incorporates portions of some tests from the [libm crate].
 Copyright © 2018 Jorge Aparicio and also dual licensed under the
-Apache 2.0 and MIT licenses. 
+Apache 2.0 and MIT licenses.
 
 [//]: # (badges)
 
 [crate-img]: https://img.shields.io/crates/v/micromath.svg?logo=rust
+
 [crate-link]: https://crates.io/crates/micromath
+
 [docs-img]: https://docs.rs/micromath/badge.svg
+
 [docs-link]: https://docs.rs/micromath/
+
 [build-image]: https://github.com/tarcieri/micromath/workflows/CI/badge.svg
+
 [build-link]: https://github.com/tarcieri/micromath/actions
+
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
+
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
-[msrv-image]: https://img.shields.io/badge/rustc-1.47+-blue.svg
+
+[msrv-image]: https://img.shields.io/badge/rustc-1.62+-blue.svg
+
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
+
 [license-link]: https://github.com/tarcieri/micromath/blob/main/LICENSE-APACHE
 
 [//]: # (general links)
 
 [`f32` extension]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html
+
 [asin]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.asin
+
 [acos]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.acos
+
 [atan]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.atan
+
 [atan2]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.atan2
+
 [cos]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.cos
+
 [hypot]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.hypot
+
 [inv]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.inv
+
 [invsqrt]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.invsqrt
+
 [ln]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.ln
+
 [log]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.log
+
 [log2]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.log2
+
 [log10]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.log10
+
 [powf]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.powf
+
 [powi]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.powi
+
 [exp]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.exp
+
 [sin]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.sin
+
 [sqrt]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.sqrt
+
 [tan]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.tan
+
 [abs]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.abs
+
 [ceil]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.ceil
+
 [floor]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.floor
+
 [round]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.round
+
 [trunc]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.trunc
+
 [fract]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.fract
+
 [copysign]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.copysign
+
 [signum]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.signum
+
 [sin_cos]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.sin_cos
+
 [mul_add]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.mul_add
+
 [recip]: https://docs.rs/micromath/latest/micromath/trait.F32Ext.html#tymethod.recip
+
 [Algebraic vector types]: https://docs.rs/micromath/latest/micromath/vector/index.html
+
 [I8x2]: https://docs.rs/micromath/latest/micromath/vector/struct.I8x2.html
+
 [I16x2]: https://docs.rs/micromath/latest/micromath/vector/struct.I16x2.html
+
 [I32x2]: https://docs.rs/micromath/latest/micromath/vector/struct.I32x2.html
+
 [U8x2]: https://docs.rs/micromath/latest/micromath/vector/struct.U8x2.html
+
 [U16x2]: https://docs.rs/micromath/latest/micromath/vector/struct.U16x2.html
+
 [U32x2]: https://docs.rs/micromath/latest/micromath/vector/struct.U32x2.html
+
 [F32x2]: https://docs.rs/micromath/latest/micromath/vector/struct.F32x2.html
+
 [I8x3]: https://docs.rs/micromath/latest/micromath/vector/struct.I8x3.html
+
 [I16x3]: https://docs.rs/micromath/latest/micromath/vector/struct.I16x3.html
+
 [I32x3]: https://docs.rs/micromath/latest/micromath/vector/struct.I32x3.html
+
 [U8x3]: https://docs.rs/micromath/latest/micromath/vector/struct.U8x3.html
+
 [U16x3]: https://docs.rs/micromath/latest/micromath/vector/struct.U16x3.html
+
 [U32x3]: https://docs.rs/micromath/latest/micromath/vector/struct.U32x3.html
+
 [F32x3]: https://docs.rs/micromath/latest/micromath/vector/struct.F32x3.html
+
 [Statistical analysis]: https://docs.rs/micromath/latest/micromath/statistics/index.html
+
 [mean]: https://docs.rs/micromath/latest/micromath/statistics/trait.Mean.html
+
 [stddev]: https://docs.rs/micromath/latest/micromath/statistics/trait.StdDev.html
+
 [trim]: https://docs.rs/micromath/latest/micromath/statistics/trim/trait.Trim.html
+
 [variance]: https://docs.rs/micromath/latest/micromath/statistics/trait.Variance.html
+
 [Quaternions]: https://docs.rs/micromath/latest/micromath/quaternion/struct.Quaternion.html
+
 [libm crate]: https://github.com/rust-lang-nursery/libm
+
 [vek crate]: https://github.com/yoanlcq/vek
+
 [approx crate]: https://crates.io/crates/approx
+
 [cc]: https://contributor-covenant.org
+
 [CODE_OF_CONDUCT.md]: https://github.com/tarcieri/micromath/blob/main/CODE_OF_CONDUCT.md

--- a/src/float.rs
+++ b/src/float.rs
@@ -636,6 +636,14 @@ impl Inv for F32 {
     }
 }
 
+#[cfg(feature = "defmt")]
+#[cfg_attr(docsrs, doc(cfg(feature = "defmt")))]
+impl defmt::Format for F32 {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(fmt, "{}", self.0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[allow(unused_imports)] // remove when we have more tests

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -352,6 +352,14 @@ where
     }
 }
 
+#[cfg(feature = "defmt")]
+#[cfg_attr(docsrs, doc(cfg(feature = "defmt")))]
+impl defmt::Format for Quaternion {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(fmt, "({}, {}, {}, {})", self.0, self.1, self.2, self.3)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Quaternion;

--- a/src/vector/vector2d.rs
+++ b/src/vector/vector2d.rs
@@ -220,3 +220,14 @@ impl From<U16x2> for F32x2 {
         }
     }
 }
+
+#[cfg(feature = "defmt")]
+#[cfg_attr(docsrs, doc(cfg(feature = "defmt")))]
+impl<C> defmt::Format for Vector2d<C>
+where
+    C: Component + defmt::Format,
+{
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(fmt, "({}, {})", self.x, self.y)
+    }
+}

--- a/src/vector/vector3d.rs
+++ b/src/vector/vector3d.rs
@@ -262,3 +262,14 @@ impl From<Vector3d<F32>> for F32x3 {
         }
     }
 }
+
+#[cfg(feature = "defmt")]
+#[cfg_attr(docsrs, doc(cfg(feature = "defmt")))]
+impl<C> defmt::Format for Vector3d<C>
+where
+    C: Component + defmt::Format,
+{
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(fmt, "({}, {}, {})", self.x, self.y, self.z)
+    }
+}


### PR DESCRIPTION
This adds support for [defmt](https://defmt.ferrous-systems.com/) via the `defmt` feature flag to simplify logging on embedded targets.