### PR TITLE
Prevent overflows in F32::inv

### DIFF
--- a/src/float/inv.rs
+++ b/src/float/inv.rs
@@ -7,7 +7,29 @@ use super::F32;
 impl F32 {
     /// Fast approximation of `1/x`.
     pub fn inv(self) -> Self {
-        Self(f32::from_bits(0x7f00_0000 - self.0.to_bits()))
+        // Check if the value is too large for the approximation, NaN (e.g. 0x7fC0_0000) or infinity.
+        let bits = self.0.to_bits();
+        if bits >= 0x7f00_0000 {
+            return if self.0.is_infinite() {
+                // 1/∞ = 0; by definition.
+                if self.0.is_sign_positive() {
+                    Self(0.0)
+                }else {
+                    Self(-0.0)
+                }
+            } else if self.0.is_nan() {
+                Self(f32::NAN)
+            } else {
+                // Values larger than the threshold result in zero for 1/x
+                Self(0.0)
+            }
+        }
+
+        // Perform the bit manipulation for the approximation
+        // The constant 0x7f00_0000 corresponds to the bit pattern for 1.0 in IEEE 754 format.
+        // Subtracting the bits of the original number from this constant effectively inverts the exponent,
+        // resulting in an approximation of the reciprocal.
+        Self(f32::from_bits(0x7f00_0000 - bits))
     }
 }
 
@@ -35,5 +57,17 @@ pub(crate) mod tests {
                 expected
             );
         }
+    }
+
+    #[test]
+    fn special_floats() {
+        assert!(f32::NAN.to_bits() > 0x7f00_0000);
+
+        assert_eq!(F32(f32::from_bits(0x7f00_0001)).inv(), F32(0.0));
+        assert!(F32(f32::NAN).inv().is_nan());
+        assert_eq!(F32(f32::INFINITY).inv(), F32(0.0));
+        assert_eq!(F32(f32::NEG_INFINITY).inv(), F32(-0.0));
+        assert!(F32(f32::INFINITY).inv().is_sign_positive());
+        assert!(F32(f32::NEG_INFINITY).inv().is_sign_negative());
     }
 }


### PR DESCRIPTION
As was pointed out in #106, large floats, but also special floats such as NaN, result in a panic when calling `F32::inv()` on them.

This adds a somewhat more complex check for these edge cases which in general should be easily skippable by the compiler or target.

I have defined the following:

- `F32(f32::from_bits(bits)).inv()` is `0.0` for any `bits > 0x7f00_0000`.
- `F32(f32::INFINITY).inv()` is `0.0`
- `F32(f32::NEG_INFINITY).inv()` is `-0.0`
- `F32(f32::NAN).inv()` is `f32:NAN`