### PR TITLE
Add From/Into array and tuple for Vector2d, Vector3d and Quaternion

### DIFF
--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -274,6 +274,18 @@ impl From<Quaternion> for (f32, f32, f32, f32) {
     }
 }
 
+impl From<[f32; 4]> for Quaternion {
+    fn from(q: [f32; 4]) -> Quaternion {
+        Self::new(q[0], q[1], q[2], q[3])
+    }
+}
+
+impl From<Quaternion> for [f32; 4] {
+    fn from(q: Quaternion) -> [f32; 4] {
+        q.to_array()
+    }
+}
+
 impl Mul for Quaternion {
     type Output = Self;
 
@@ -444,5 +456,25 @@ mod tests {
         let v1_r = q.rotate(v1);
 
         assert!((v1_r - v2).magnitude() < 1e-1);
+    }
+
+    #[test]
+    fn from_tuple() {
+        let quat: Quaternion = (1.0, 2.0, 3.0, 4.0).into();
+        let (a, b, c, d) = quat.into();
+        assert_eq!(a, 1.0);
+        assert_eq!(b, 2.0);
+        assert_eq!(c, 3.0);
+        assert_eq!(d, 4.0);
+    }
+
+    #[test]
+    fn from_array() {
+        let quat: Quaternion = [1.0, 2.0, 3.0, 4.0].into();
+        let quat: [f32; 4] = quat.into();
+        assert_eq!(quat[0], 1.0);
+        assert_eq!(quat[1], 2.0);
+        assert_eq!(quat[2], 3.0);
+        assert_eq!(quat[3], 4.0);
     }
 }

--- a/src/vector/vector2d.rs
+++ b/src/vector/vector2d.rs
@@ -101,6 +101,36 @@ where
     }
 }
 
+impl<C> From<Vector2d<C>> for (C, C)
+where
+    C: Component,
+{
+    fn from(vector: Vector2d<C>) -> (C, C) {
+        (vector.x, vector.y)
+    }
+}
+
+impl<C> From<[C; 2]> for Vector2d<C>
+where
+    C: Component,
+{
+    fn from(vector: [C; 2]) -> Self {
+        Self {
+            x: vector[0],
+            y: vector[1],
+        }
+    }
+}
+
+impl<C> From<Vector2d<C>> for [C; 2]
+where
+    C: Component,
+{
+    fn from(vector: Vector2d<C>) -> [C; 2] {
+        vector.to_array()
+    }
+}
+
 impl<C> Index<usize> for Vector2d<C>
 where
     C: Component,
@@ -218,5 +248,32 @@ impl From<U16x2> for F32x2 {
             x: vector.x.into(),
             y: vector.y.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_tuple() {
+        let vec: Vector2d<_> = (1, 2).into();
+        assert_eq!(vec[0], 1);
+        assert_eq!(vec[1], 2);
+
+        let (x, y) = vec.into();
+        assert_eq!(x, 1);
+        assert_eq!(y, 2);
+    }
+
+    #[test]
+    fn from_array() {
+        let vec: Vector2d<_> = [1, 2].into();
+        assert_eq!(vec[0], 1);
+        assert_eq!(vec[1], 2);
+
+        let arr: [_; 2] = vec.into();
+        assert_eq!(arr[0], 1);
+        assert_eq!(arr[1], 2);
     }
 }

--- a/src/vector/vector3d.rs
+++ b/src/vector/vector3d.rs
@@ -108,6 +108,37 @@ where
     }
 }
 
+impl<C> From<Vector3d<C>> for (C, C, C)
+where
+    C: Component,
+{
+    fn from(vector: Vector3d<C>) -> (C, C, C) {
+        (vector.x, vector.y, vector.z)
+    }
+}
+
+impl<C> From<[C; 3]> for Vector3d<C>
+where
+    C: Component,
+{
+    fn from(vector: [C; 3]) -> Self {
+        Self {
+            x: vector[0],
+            y: vector[1],
+            z: vector[2],
+        }
+    }
+}
+
+impl<C> From<Vector3d<C>> for [C; 3]
+where
+    C: Component,
+{
+    fn from(vector: Vector3d<C>) -> [C; 3] {
+        vector.to_array()
+    }
+}
+
 impl<C> Index<usize> for Vector3d<C>
 where
     C: Component,
@@ -260,5 +291,36 @@ impl From<Vector3d<F32>> for F32x3 {
             y: vector.y.into(),
             z: vector.z.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_tuple() {
+        let vec: Vector3d<_> = (1, 2, 3).into();
+        assert_eq!(vec[0], 1);
+        assert_eq!(vec[1], 2);
+        assert_eq!(vec[2], 3);
+
+        let (x, y, z) = vec.into();
+        assert_eq!(x, 1);
+        assert_eq!(y, 2);
+        assert_eq!(z, 3);
+    }
+
+    #[test]
+    fn from_array() {
+        let vec: Vector3d<_> = [1, 2, 3].into();
+        assert_eq!(vec[0], 1);
+        assert_eq!(vec[1], 2);
+        assert_eq!(vec[2], 3);
+
+        let arr: [_; 3] = vec.into();
+        assert_eq!(arr[0], 1);
+        assert_eq!(arr[1], 2);
+        assert_eq!(arr[2], 3);
     }
 }


### PR DESCRIPTION
This adds `From<Vector2d<C>> for [C; 2]` and `From<Vector3d<C>> for [C; 3]` (and their Into, as well as tuple counterparts). The functions `to_array()` already existed, so this simply expresses it as a trait implementation.

Same for `Quaternion` to keep the symmetry in behavior, the `to_array` function also existed here already.