### PR TITLE
Add cross and dot for Vector2d and Vector3d

### DIFF
--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -67,8 +67,6 @@ impl Quaternion {
         C: Component + Into<f32>,
     {
         // Implementation from http://lolengine.net/blog/2014/02/24/quaternion-from-two-vectors-final
-        use crate::vector::Vector;
-
         let n_uv = F32(u.dot(u).into() * v.dot(v).into()).sqrt();
         let mut realpart = n_uv + u.dot(v).into();
 

--- a/src/vector/vector2d.rs
+++ b/src/vector/vector2d.rs
@@ -41,11 +41,6 @@ impl<C> Vector2d<C>
 where
     C: Component,
 {
-    /// Initializes a new instance of the `Vector2d` struct.
-    pub fn new(x: C, y: C) -> Self {
-        Self { x, y }
-    }
-
     /// Return a 2-element array containing the coordinates
     // TODO(tarcieri): move this to the `Vector` trait leveraging const generics?
     pub fn to_array(&self) -> [C; 2] {
@@ -331,8 +326,8 @@ mod tests {
 
     #[test]
     fn cross() {
-        let lhs = Vector2d::new(1, 2);
-        let rhs = Vector2d::new(3, 4);
+        let lhs = Vector2d { x: 1, y: 2 };
+        let rhs = Vector2d { x: 3, y: 4 };
         let cross = lhs.cross(rhs);
         assert_eq!(cross.x, 0);
         assert_eq!(cross.y, 0);
@@ -347,8 +342,8 @@ mod tests {
 
     #[test]
     fn dot() {
-        let lhs = Vector2d::new(1, 2);
-        let rhs = Vector2d::new(3, 4);
+        let lhs = Vector2d { x: 1, y: 2 };
+        let rhs = Vector2d { x: 3, y: 4 };
         let dot = lhs.dot(rhs);
         assert_eq!(dot, 11);
     }

--- a/src/vector/vector2d.rs
+++ b/src/vector/vector2d.rs
@@ -57,9 +57,22 @@ where
         (self.x * rhs.x) + (self.y * rhs.y)
     }
 
+    /// Calculates the perpendicular dot product.
+    ///
+    /// This value can be understood as the `z` component of the [`cross`](Self::cross) product
+    /// between two `Vector2d` instances in 3D space, or the signed area of the parallelogram
+    /// formed by the two vectors.
+    ///
+    /// This value can be used to perform side tests without having to promote the vectors
+    /// into [`Vector3d`] instances.
+    pub fn perpendicular_dot(self, rhs: Self) -> C {
+        (self.x * rhs.y) - (self.y * rhs.x)
+    }
+
     /// Calculates the outer product.
     ///
-    /// Note that due to tye type of operation, the result is a [`Vector3d`], not a [`Vector2d`].
+    /// Note that due to tye type of operation, the result is a [`Vector3d`], not a `Vector2d`.
+    /// See also [`perpendicular_dot`](Self::perpendicular_dot) for a simplified version.
     pub fn cross(&self, rhs: Self) -> Vector3d<C> {
         Vector3d::from(*self) * Vector3d::from(rhs)
     }
@@ -327,6 +340,9 @@ mod tests {
 
         let mul = lhs * rhs;
         assert_eq!(mul, cross);
+
+        let perp_dot = lhs.perpendicular_dot(rhs);
+        assert_eq!(perp_dot, cross.z);
     }
 
     #[test]

--- a/src/vector/vector2d.rs
+++ b/src/vector/vector2d.rs
@@ -1,6 +1,6 @@
 //! 2-dimensional vector
 
-use super::{Component, Vector};
+use super::{Component, Vector, Vector3d};
 use core::{
     iter::FromIterator,
     ops::{Add, AddAssign, Index, Mul, MulAssign, Sub, SubAssign},
@@ -41,10 +41,27 @@ impl<C> Vector2d<C>
 where
     C: Component,
 {
+    /// Initializes a new instance of the `Vector2d` struct.
+    pub fn new(x: C, y: C) -> Self {
+        Self { x, y }
+    }
+
     /// Return a 2-element array containing the coordinates
     // TODO(tarcieri): move this to the `Vector` trait leveraging const generics?
     pub fn to_array(&self) -> [C; 2] {
         [self.x, self.y]
+    }
+
+    /// Calculates the inner product.
+    pub fn dot(self, rhs: Self) -> C {
+        (self.x * rhs.x) + (self.y * rhs.y)
+    }
+
+    /// Calculates the outer product.
+    ///
+    /// Note that due to tye type of operation, the result is a [`Vector3d`], not a [`Vector2d`].
+    pub fn cross(&self, rhs: Self) -> Vector3d<C> {
+        Vector3d::from(*self) * Vector3d::from(rhs)
     }
 }
 
@@ -85,7 +102,7 @@ where
     }
 
     fn dot(self, rhs: Self) -> C {
-        (self.x * rhs.x) + (self.y * rhs.y)
+        self.dot(rhs)
     }
 }
 
@@ -206,6 +223,17 @@ where
     }
 }
 
+impl<C> Mul<Vector2d<C>> for Vector2d<C>
+where
+    C: Component,
+{
+    type Output = Vector3d<C>;
+
+    fn mul(self, rhs: Vector2d<C>) -> Vector3d<C> {
+        self.cross(rhs)
+    }
+}
+
 impl<C> MulAssign<C> for Vector2d<C>
 where
     C: Component,
@@ -286,5 +314,26 @@ mod tests {
         let arr: [_; 2] = vec.into();
         assert_eq!(arr[0], 1);
         assert_eq!(arr[1], 2);
+    }
+
+    #[test]
+    fn cross() {
+        let lhs = Vector2d::new(1, 2);
+        let rhs = Vector2d::new(3, 4);
+        let cross = lhs.cross(rhs);
+        assert_eq!(cross.x, 0);
+        assert_eq!(cross.y, 0);
+        assert_eq!(cross.z, -2);
+
+        let mul = lhs * rhs;
+        assert_eq!(mul, cross);
+    }
+
+    #[test]
+    fn dot() {
+        let lhs = Vector2d::new(1, 2);
+        let rhs = Vector2d::new(3, 4);
+        let dot = lhs.dot(rhs);
+        assert_eq!(dot, 11);
     }
 }

--- a/src/vector/vector3d.rs
+++ b/src/vector/vector3d.rs
@@ -1,6 +1,6 @@
 //! 3-dimensional vector
 
-use super::{Component, Vector};
+use super::{Component, Vector, Vector2d};
 use crate::F32;
 use core::{
     iter::FromIterator,
@@ -45,10 +45,29 @@ impl<C> Vector3d<C>
 where
     C: Component,
 {
+    /// Initializes a new instance of the `Vector3d` struct.
+    pub fn new(x: C, y: C, z: C) -> Self {
+        Self { x, y, z }
+    }
+
     /// Return a 3-element array containing the coordinates
     // TODO(tarcieri): move this to the `Vector` trait leveraging const generics?
     pub fn to_array(&self) -> [C; 3] {
         [self.x, self.y, self.z]
+    }
+
+    /// Calculates the inner product.
+    pub fn dot(self, rhs: Self) -> C {
+        (self.x * rhs.x) + (self.y * rhs.y) + (self.z * rhs.z)
+    }
+
+    /// Calculates the outer product.
+    pub fn cross(&self, rhs: Self) -> Vector3d<C> {
+        Self {
+            x: (self.y * rhs.z) - (self.z * rhs.y),
+            y: (self.z * rhs.x) - (self.x * rhs.z),
+            z: (self.x * rhs.y) - (self.y * rhs.x),
+        }
     }
 }
 
@@ -92,6 +111,20 @@ where
 
     fn dot(self, rhs: Self) -> C {
         (self.x * rhs.x) + (self.y * rhs.y) + (self.z * rhs.z)
+    }
+}
+
+impl<C> From<Vector2d<C>> for Vector3d<C>
+where
+    C: Component,
+{
+    fn from(vector: Vector2d<C>) -> Self {
+        let zero = C::default();
+        Self {
+            x: vector.x,
+            y: vector.y,
+            z: zero,
+        }
     }
 }
 
@@ -211,11 +244,7 @@ where
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: (self.y * rhs.z) - (self.z * rhs.y),
-            y: (self.z * rhs.x) - (self.x * rhs.z),
-            z: (self.x * rhs.y) - (self.y * rhs.x),
-        }
+        self.cross(rhs)
     }
 }
 
@@ -333,5 +362,26 @@ mod tests {
         assert_eq!(arr[0], 1);
         assert_eq!(arr[1], 2);
         assert_eq!(arr[2], 3);
+    }
+
+    #[test]
+    fn cross() {
+        let lhs = Vector3d::new(1, 2, 3);
+        let rhs = Vector3d::new(4, 5, 6);
+        let cross = lhs.cross(rhs);
+        assert_eq!(cross.x, -3);
+        assert_eq!(cross.y, 6);
+        assert_eq!(cross.z, -3);
+
+        let mul = lhs * rhs;
+        assert_eq!(mul, cross);
+    }
+
+    #[test]
+    fn dot() {
+        let lhs = Vector3d::new(1, 2, 3);
+        let rhs = Vector3d::new(4, 5, 6);
+        let dot = lhs.dot(rhs);
+        assert_eq!(dot, 32);
     }
 }

--- a/src/vector/vector3d.rs
+++ b/src/vector/vector3d.rs
@@ -45,11 +45,6 @@ impl<C> Vector3d<C>
 where
     C: Component,
 {
-    /// Initializes a new instance of the `Vector3d` struct.
-    pub fn new(x: C, y: C, z: C) -> Self {
-        Self { x, y, z }
-    }
-
     /// Return a 3-element array containing the coordinates
     // TODO(tarcieri): move this to the `Vector` trait leveraging const generics?
     pub fn to_array(&self) -> [C; 3] {
@@ -366,8 +361,8 @@ mod tests {
 
     #[test]
     fn cross() {
-        let lhs = Vector3d::new(1, 2, 3);
-        let rhs = Vector3d::new(4, 5, 6);
+        let lhs = Vector3d { x: 1, y: 2, z: 3 };
+        let rhs = Vector3d { x: 4, y: 5, z: 6 };
         let cross = lhs.cross(rhs);
         assert_eq!(cross.x, -3);
         assert_eq!(cross.y, 6);
@@ -379,8 +374,8 @@ mod tests {
 
     #[test]
     fn dot() {
-        let lhs = Vector3d::new(1, 2, 3);
-        let rhs = Vector3d::new(4, 5, 6);
+        let lhs = Vector3d { x: 1, y: 2, z: 3 };
+        let rhs = Vector3d { x: 4, y: 5, z: 6 };
         let dot = lhs.dot(rhs);
         assert_eq!(dot, 32);
     }


### PR DESCRIPTION
This may go a bit against your philosophy judging from the comments on the `to_array` function(s). Here's what I did:

* I added the `cross` and `dot` functions to `Vector2d` and `Vector3d` explicitly; they still remain part of the trait, but the trait impl forwards to the concrete implementations.
* Since for `Vector2d` the cross-product lies outside of the plane, it promotes to `Vector3d` internally. This is still useful when determining which side of a line a point lies on, for example, as the Z component indicates that direction and distance.
* The `perpendicular_dot` function performs the same but directly calculates the Z component since the others would be zero in "2D" space.

All in all, just a bit more symmetry between a types and a bit of convenience for a common 2D calculation.