### PR TITLE
Add vector normalization to Vector trait

### DIFF
--- a/src/float.rs
+++ b/src/float.rs
@@ -226,7 +226,7 @@ impl F32 {
     /// Is this floating point value even?
     fn is_even(&self) -> bool {
         // any floating point value that doesn't fit in an i32 range is even,
-        // and will loose 1's digit precision at exp values of 23+
+        // and will lose 1's digit precision at exp values of 23+
         if self.extract_exponent_value() >= 31 {
             true
         } else {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -72,4 +72,37 @@ where
             .sum::<f32>()
             .sqrt()
     }
+
+    /// Returns a normalized version of the vector.
+    fn normalized(self) -> Self
+    where
+        Self: FromIterator<C>,
+        C: Into<f32> + From<f32>,
+    {
+        let norm = self.magnitude();
+        let normalized = self.iter().map(|n| n.into() / norm).map(C::from);
+        Self::from_iter(normalized)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalized() {
+        const ERROR: f32 = 1e-6;
+        let vec = Vector3d {
+            x: 3.0,
+            y: 4.0,
+            z: 5.0,
+        };
+        let norm = vec.magnitude();
+        assert!((norm - 7.071068).abs() <= ERROR);
+
+        let normalized = vec.normalized();
+        assert!((normalized.x - 0.42426407).abs() <= ERROR);
+        assert!((normalized.y - 0.56568545).abs() <= ERROR);
+        assert!((normalized.z - 0.70710677).abs() <= ERROR);
+    }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -74,14 +74,22 @@ where
     }
 
     /// Returns a normalized version of the vector.
-    fn normalized(self) -> Self
+    fn normalized(mut self) -> Self
     where
         Self: FromIterator<C>,
         C: Into<f32> + From<f32>,
     {
         let norm = self.magnitude();
-        let normalized = self.iter().map(|n| n.into() / norm).map(C::from);
-        Self::from_iter(normalized)
+        self.map(|n| C::from(n.into() / norm))
+    }
+
+    /// Applies a function to each element of the vector
+    /// and returns a new vector of the transformed elements.
+    fn map<F>(&mut self, map: F) -> Self
+    where
+        F: FnMut(C) -> C,
+    {
+        Self::from_iter(self.iter().map(map))
     }
 }
 


### PR DESCRIPTION
This addresses #99 and performs vector normalization by reusing the existing `magnitude` implementation, i.e. it goes through `f32`, normalizes in `f32` and then converts back to `C` by using `FromIterator`.

---

I attempted pre-calculating the inverse of the magnitude and then multiplying by that, but it brought the results too far off in terms of error.

I thought about factoring out `invsqrt` into a trait and then implement that trait for `F32` and `f32` alike. This way the `magnitude` function could be more generic (`C: InvSqrt` instead of `C: Into<f32>`) and wouldn't require the use of `f32` explicitly.