### PR TITLE
Add commutative multiplication on primitive scalar types for Vectors

### DIFF
--- a/src/vector.rs
+++ b/src/vector.rs
@@ -3,6 +3,7 @@
 //! All vectors types impl the [Vector] trait, and all vector components
 //! impl the [Component] trait.
 
+mod commutative;
 mod component;
 mod iter;
 mod vector2d;

--- a/src/vector/commutative.rs
+++ b/src/vector/commutative.rs
@@ -1,0 +1,22 @@
+/// Implements standard commutative operations such as Add and Mul on primitive types.
+macro_rules! impl_commutative {
+    ($vector:ident, $component:ident) => {
+        impl Add<$vector<$component>> for $component {
+            type Output = $vector<$component>;
+
+            fn add(self, rhs: $vector<$component>) -> Self::Output {
+                <$vector<$component> as Add<$component>>::add(rhs, self)
+            }
+        }
+
+        impl Mul<$vector<$component>> for $component {
+            type Output = $vector<$component>;
+
+            fn mul(self, rhs: $vector<$component>) -> Self::Output {
+                rhs.mul(self)
+            }
+        }
+    };
+}
+
+pub(crate) use impl_commutative;

--- a/src/vector/commutative.rs
+++ b/src/vector/commutative.rs
@@ -1,14 +1,6 @@
 /// Implements standard commutative operations such as Add and Mul on primitive types.
 macro_rules! impl_commutative {
     ($vector:ident, $component:ident) => {
-        impl Add<$vector<$component>> for $component {
-            type Output = $vector<$component>;
-
-            fn add(self, rhs: $vector<$component>) -> Self::Output {
-                <$vector<$component> as Add<$component>>::add(rhs, self)
-            }
-        }
-
         impl Mul<$vector<$component>> for $component {
             type Output = $vector<$component>;
 

--- a/src/vector/vector2d.rs
+++ b/src/vector/vector2d.rs
@@ -205,20 +205,6 @@ where
     }
 }
 
-impl<C> Add<C> for Vector2d<C>
-where
-    C: Component,
-{
-    type Output = Self;
-
-    fn add(self, rhs: C) -> Self {
-        Self {
-            x: self.x + rhs,
-            y: self.y + rhs,
-        }
-    }
-}
-
 impl<C> Sub for Vector2d<C>
 where
     C: Component,
@@ -239,20 +225,6 @@ where
 {
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
-    }
-}
-
-impl<C> Sub<C> for Vector2d<C>
-where
-    C: Component,
-{
-    type Output = Self;
-
-    fn sub(self, rhs: C) -> Self {
-        Self {
-            x: self.x - rhs,
-            y: self.y - rhs,
-        }
     }
 }
 

--- a/src/vector/vector2d.rs
+++ b/src/vector/vector2d.rs
@@ -1,6 +1,8 @@
 //! 2-dimensional vector
 
 use super::{Component, Vector, Vector3d};
+use crate::vector::commutative::impl_commutative;
+use crate::F32;
 use core::{
     iter::FromIterator,
     ops::{Add, AddAssign, Index, Mul, MulAssign, Sub, SubAssign},
@@ -26,6 +28,15 @@ pub type U32x2 = Vector2d<u32>;
 
 /// 2-dimensional XY vector of `f32` values
 pub type F32x2 = Vector2d<f32>;
+
+impl_commutative!(Vector2d, i8);
+impl_commutative!(Vector2d, i16);
+impl_commutative!(Vector2d, i32);
+impl_commutative!(Vector2d, u8);
+impl_commutative!(Vector2d, u16);
+impl_commutative!(Vector2d, u32);
+impl_commutative!(Vector2d, f32);
+impl_commutative!(Vector2d, F32);
 
 /// 2-dimensional vector
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -194,6 +205,20 @@ where
     }
 }
 
+impl<C> Add<C> for Vector2d<C>
+where
+    C: Component,
+{
+    type Output = Self;
+
+    fn add(self, rhs: C) -> Self {
+        Self {
+            x: self.x + rhs,
+            y: self.y + rhs,
+        }
+    }
+}
+
 impl<C> Sub for Vector2d<C>
 where
     C: Component,
@@ -214,6 +239,20 @@ where
 {
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
+    }
+}
+
+impl<C> Sub<C> for Vector2d<C>
+where
+    C: Component,
+{
+    type Output = Self;
+
+    fn sub(self, rhs: C) -> Self {
+        Self {
+            x: self.x - rhs,
+            y: self.y - rhs,
+        }
     }
 }
 

--- a/src/vector/vector3d.rs
+++ b/src/vector/vector3d.rs
@@ -216,21 +216,6 @@ where
     }
 }
 
-impl<C> Add<C> for Vector3d<C>
-where
-    C: Component,
-{
-    type Output = Self;
-
-    fn add(self, rhs: C) -> Self {
-        Self {
-            x: self.x + rhs,
-            y: self.y + rhs,
-            z: self.z + rhs,
-        }
-    }
-}
-
 impl<C> Sub for Vector3d<C>
 where
     C: Component,
@@ -252,21 +237,6 @@ where
 {
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
-    }
-}
-
-impl<C> Sub<C> for Vector3d<C>
-where
-    C: Component,
-{
-    type Output = Self;
-
-    fn sub(self, rhs: C) -> Self {
-        Self {
-            x: self.x - rhs,
-            y: self.y - rhs,
-            z: self.z - rhs,
-        }
     }
 }
 

--- a/src/vector/vector3d.rs
+++ b/src/vector/vector3d.rs
@@ -1,6 +1,6 @@
 //! 3-dimensional vector
 
-use super::{Component, Vector, Vector2d};
+use super::{commutative::impl_commutative, Component, Vector, Vector2d};
 use crate::F32;
 use core::{
     iter::FromIterator,
@@ -27,6 +27,15 @@ pub type U32x3 = Vector3d<u32>;
 
 /// 3-dimensional XYZ vector of `f32` values
 pub type F32x3 = Vector3d<f32>;
+
+impl_commutative!(Vector3d, i8);
+impl_commutative!(Vector3d, i16);
+impl_commutative!(Vector3d, i32);
+impl_commutative!(Vector3d, u8);
+impl_commutative!(Vector3d, u16);
+impl_commutative!(Vector3d, u32);
+impl_commutative!(Vector3d, f32);
+impl_commutative!(Vector3d, F32);
 
 /// 3-dimensional vector
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
@@ -207,6 +216,21 @@ where
     }
 }
 
+impl<C> Add<C> for Vector3d<C>
+where
+    C: Component,
+{
+    type Output = Self;
+
+    fn add(self, rhs: C) -> Self {
+        Self {
+            x: self.x + rhs,
+            y: self.y + rhs,
+            z: self.z + rhs,
+        }
+    }
+}
+
 impl<C> Sub for Vector3d<C>
 where
     C: Component,
@@ -228,6 +252,21 @@ where
 {
     fn sub_assign(&mut self, other: Self) {
         *self = *self - other;
+    }
+}
+
+impl<C> Sub<C> for Vector3d<C>
+where
+    C: Component,
+{
+    type Output = Self;
+
+    fn sub(self, rhs: C) -> Self {
+        Self {
+            x: self.x - rhs,
+            y: self.y - rhs,
+            z: self.z - rhs,
+        }
     }
 }
 


### PR DESCRIPTION
This one partially addresses #105 and the implementation is somewhat debatable. In general, commutative operations (e.g. `Mul<C> for Vector3d<C>` and `Mul<Vector3d<C>> for C`) cannot be implemented due to trait implementation coherence rules.

Given that the crate exports some standard types such as `F32x2`, `I16x3` etc. it is at least possible to define commutative math for these specific implementations, and this is what this PR does.
