### PR TITLE
Add scalar division for vectors

### DIFF
--- a/src/vector/vector2d.rs
+++ b/src/vector/vector2d.rs
@@ -3,6 +3,7 @@
 use super::{Component, Vector, Vector3d};
 use crate::vector::commutative::impl_commutative;
 use crate::F32;
+use core::ops::{Div, DivAssign};
 use core::{
     iter::{FromIterator, Sum},
     ops::{Add, AddAssign, Index, Mul, MulAssign, Sub, SubAssign},
@@ -262,6 +263,30 @@ where
     }
 }
 
+impl<C> Div<C> for Vector2d<C>
+where
+    C: Component,
+{
+    type Output = Self;
+
+    fn div(self, rhs: C) -> Self {
+        Self {
+            x: self.x / rhs,
+            y: self.y / rhs,
+        }
+    }
+}
+
+impl<C> DivAssign<C> for Vector2d<C>
+where
+    C: Component,
+{
+    fn div_assign(&mut self, rhs: C) {
+        self.x = self.x / rhs;
+        self.y = self.y / rhs;
+    }
+}
+
 impl<C> Sum<Vector2d<C>> for Vector2d<C>
 where
     C: Component,
@@ -403,5 +428,21 @@ mod tests {
         let rhs = Vector2d { x: 3, y: 4 };
         let dot = lhs.dot(rhs);
         assert_eq!(dot, 11);
+    }
+
+    #[test]
+    fn div() {
+        let vec = Vector2d { x: 10, y: 20 };
+        let result = vec / 2;
+        assert_eq!(result.x, 5);
+        assert_eq!(result.y, 10);
+    }
+
+    #[test]
+    fn div_assign() {
+        let mut vec = Vector2d { x: 10, y: 20 };
+        vec /= 2;
+        assert_eq!(vec.x, 5);
+        assert_eq!(vec.y, 10);
     }
 }

--- a/src/vector/vector3d.rs
+++ b/src/vector/vector3d.rs
@@ -2,9 +2,9 @@
 
 use super::{commutative::impl_commutative, Component, Vector, Vector2d};
 use crate::F32;
-use core::iter::Sum;
+use core::ops::{Div, DivAssign};
 use core::{
-    iter::FromIterator,
+    iter::{FromIterator, Sum},
     ops::{Add, AddAssign, Index, Mul, MulAssign, Sub, SubAssign},
 };
 
@@ -278,6 +278,32 @@ where
     }
 }
 
+impl<C> Div<C> for Vector3d<C>
+where
+    C: Component,
+{
+    type Output = Self;
+
+    fn div(self, rhs: C) -> Self {
+        Self {
+            x: self.x / rhs,
+            y: self.y / rhs,
+            z: self.z / rhs,
+        }
+    }
+}
+
+impl<C> DivAssign<C> for Vector3d<C>
+where
+    C: Component,
+{
+    fn div_assign(&mut self, rhs: C) {
+        self.x = self.x / rhs;
+        self.y = self.y / rhs;
+        self.z = self.z / rhs;
+    }
+}
+
 impl<C> Sum<Vector3d<C>> for Vector3d<C>
 where
     C: Component,
@@ -436,5 +462,31 @@ mod tests {
         let rhs = Vector3d { x: 4, y: 5, z: 6 };
         let dot = lhs.dot(rhs);
         assert_eq!(dot, 32);
+    }
+
+    #[test]
+    fn div() {
+        let vec = Vector3d {
+            x: 10,
+            y: 20,
+            z: 30,
+        };
+        let result = vec / 2;
+        assert_eq!(result.x, 5);
+        assert_eq!(result.y, 10);
+        assert_eq!(result.z, 15);
+    }
+
+    #[test]
+    fn div_assign() {
+        let mut vec = Vector3d {
+            x: 10,
+            y: 20,
+            z: 30,
+        };
+        vec /= 2;
+        assert_eq!(vec.x, 5);
+        assert_eq!(vec.y, 10);
+        assert_eq!(vec.z, 15);
     }
 }


### PR DESCRIPTION
Second part of #105 that adds scalar division to vectors. Only the standard division (`Div<C> for VectorXd<C>`) is implemented, not the left-handed version of it.