### PR TITLE
Add magnitude_sq function to support non-f32

### DIFF
--- a/src/float.rs
+++ b/src/float.rs
@@ -226,7 +226,7 @@ impl F32 {
     /// Is this floating point value even?
     fn is_even(&self) -> bool {
         // any floating point value that doesn't fit in an i32 range is even,
-        // and will loose 1's digit precision at exp values of 23+
+        // and will lose 1's digit precision at exp values of 23+
         if self.extract_exponent_value() >= 31 {
             true
         } else {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -59,6 +59,14 @@ where
         differences.map(|n| n * n).sum::<f32>().sqrt()
     }
 
+    /// Compute the squared magnitude of a vector
+    fn magnitude_sq(self) -> C
+    where
+        C: core::iter::Sum,
+    {
+        self.iter().map(|n| n * n).sum()
+    }
+
     /// Compute the magnitude of a vector
     fn magnitude(self) -> f32
     where
@@ -71,5 +79,21 @@ where
             })
             .sum::<f32>()
             .sqrt()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn magnitude_sq() {
+        let vec = Vector3d {
+            x: 3.0,
+            y: 4.0,
+            z: 5.0,
+        };
+        let mag = vec.magnitude_sq();
+        assert_eq!(mag, 3.0 * 3.0 + 4.0 * 4.0 + 5.0 * 5.0);
     }
 }


### PR DESCRIPTION
Extracted from #114, this provides the `magnitude_sq` function that calculates the squared magnitude of a vector (e.g. as the squared Euclidean distance between two points). This function is useful in general to speed up relative comparisons where taking the square root isn't strictly necessary, e.g. sorting by distance, as the square root function is monotonic and therefore doesn't change the outcome.

This also allows for `C: Component` types that re not `Into<f32>` to partially calculate the vector norm, as the current 
`magnitude` function is strictly limited to `f32` results.