### PR TITLE
Allow mean on both f32 and &f32

### DIFF
--- a/src/statistics/mean.rs
+++ b/src/statistics/mean.rs
@@ -1,5 +1,5 @@
 /// Arithmetic mean
-pub trait Mean {
+pub trait Mean<I> {
     /// Result type
     type Result;
 
@@ -7,7 +7,7 @@ pub trait Mean {
     fn mean(self) -> Self::Result;
 }
 
-impl<I> Mean for I
+impl<I> Mean<f32> for I
 where
     I: Iterator<Item = f32>,
 {
@@ -26,12 +26,25 @@ where
     }
 }
 
+impl<'a, I> Mean<&f32> for I
+where
+    I: Iterator<Item = &'a f32>,
+{
+    type Result = f32;
+
+    fn mean(self) -> f32 {
+        self.copied().mean()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Mean;
 
     #[test]
     fn mean_test() {
-        assert_eq!([1.0, 3.0, 5.0].iter().cloned().mean(), 3.0);
+        assert_eq!([1.0, 3.0, 5.0].iter().mean(), 3.0);
+
+        assert_eq!([1.0, 3.0, 5.0].into_iter().mean(), 3.0);
     }
 }

--- a/src/statistics/mean.rs
+++ b/src/statistics/mean.rs
@@ -1,23 +1,36 @@
 /// Arithmetic mean
-pub trait Mean<I> {
-    /// Result type
-    type Result;
 
-    /// Compute the arithmetic mean
-    fn mean(self) -> Self::Result;
+/// Provide the Mean trait for Iterators
+pub trait MeanExt: Iterator {
+    /// Compute the arithmetic mean of this iterator
+    fn mean(self) -> f32
+    where
+        Self: Sized,
+        f32: Mean<Self::Item>,
+    {
+        f32::mean(self)
+    }
 }
 
-impl<I> Mean<f32> for I
-where
-    I: Iterator<Item = f32>,
-{
-    type Result = f32;
+impl<I: Iterator> MeanExt for I {}
 
-    fn mean(self) -> f32 {
+/// Types for which a mean can be calculated
+pub trait Mean<A = Self> {
+    /// Compute the arithmetic mean of the given iterator
+    fn mean<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = A>;
+}
+
+impl Mean for f32 {
+    fn mean<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = f32>,
+    {
         let mut num_items = 0;
         let mut sum = 0.0;
 
-        for item in self {
+        for item in iter {
             num_items += 1;
             sum += item;
         }
@@ -26,25 +39,23 @@ where
     }
 }
 
-impl<'a, I> Mean<&f32> for I
-where
-    I: Iterator<Item = &'a f32>,
-{
-    type Result = f32;
-
-    fn mean(self) -> f32 {
-        self.copied().mean()
+impl<'a> Mean<&'a f32> for f32 {
+    fn mean<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a f32>,
+    {
+        iter.copied().mean()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Mean;
+    use super::MeanExt;
 
     #[test]
     fn mean_test() {
         assert_eq!([1.0, 3.0, 5.0].iter().mean(), 3.0);
 
-        assert_eq!([1.0, 3.0, 5.0].into_iter().mean(), 3.0);
+        assert_eq!(IntoIterator::into_iter([1.0, 3.0, 5.0]).mean(), 3.0);
     }
 }

--- a/src/statistics/trim.rs
+++ b/src/statistics/trim.rs
@@ -1,6 +1,6 @@
 //! Iterate over input slices after culling statistical outliers.
 
-use super::mean::Mean;
+use super::mean::MeanExt;
 #[allow(unused_imports)]
 use crate::F32Ext;
 use core::{iter, slice};

--- a/src/statistics/variance.rs
+++ b/src/statistics/variance.rs
@@ -1,4 +1,4 @@
-use super::mean::Mean;
+use super::mean::MeanExt;
 
 /// Statistical variance
 pub trait Variance {


### PR DESCRIPTION
The two patches are somewhat independent. The first is the 'minimal' change to allow using a Iterator<Item = &f32>`. The second is a more complete implementation, inspired by the constructs used in the standard library.

Feel free to pick either!


Fixes #121

----

Hm, I just realized that micromath is in 2.1 :smiling_face_with_tear: so this would not fly for a minor/patch release.

If you don't plan on releasing 3.x, it can't be implemented AFAIK. Since `Mean` takes no arguments, there's only ever a single instance of it and as such can't be implemented for differing `I`

